### PR TITLE
Pin dependency closure (lockfile) + warm-machine fly.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy requirements and install Python dependencies
-COPY requirements.lightweight.txt ./
-RUN pip install --no-cache-dir -r requirements.lightweight.txt
+# Copy requirements and install Python dependencies.
+# Install from the fully pinned lockfile (complete transitive closure) so the
+# build is deterministic — re-resolving transitive deps once dropped
+# importlib_metadata and crash-looped the app on boot. requirements.lightweight.txt
+# is kept as the human-edited source of direct deps; regenerate the lock from it.
+COPY requirements.lock.txt requirements.lightweight.txt ./
+RUN pip install --no-cache-dir -r requirements.lock.txt
 
 # Create a non-root user with specific UID/GID
 RUN groupadd --system --gid 10001 app && \

--- a/fly.toml
+++ b/fly.toml
@@ -10,9 +10,9 @@ primary_region = "ord"  # Change to your preferred region
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = false  # Don't auto-stop: it was killing in-flight background digests mid-run
   auto_start_machines = true
-  min_machines_running = 0  # Scale to zero when idle to save costs
+  min_machines_running = 1  # Keep one machine warm so the daily digest run isn't stopped mid-flight
   processes = ["app"]
 
   # Health check disabled during initial deployment

--- a/requirements.lightweight.txt
+++ b/requirements.lightweight.txt
@@ -1,3 +1,11 @@
+# =============================================================================
+# Top-level (direct) dependencies — the "what we want".
+# The Docker image does NOT install from this file; it installs from the fully
+# pinned requirements.lock.txt (complete transitive closure) so rebuilds are
+# deterministic. Edit deps here, then regenerate the lock (see that file's
+# header). Keep the two in sync.
+# =============================================================================
+
 # Core framework
 fastapi==0.115.6
 uvicorn[standard]==0.34.0
@@ -18,6 +26,11 @@ python-multipart==0.0.20
 logfire==2.8.0
 typing-extensions==4.12.2
 tenacity==9.0.0  # Add for retry logic
+
+# Pinned transitive (drift guard): logfire -> opentelemetry pulls this in, but a
+# fresh resolve once dropped it and crash-looped boot with
+# "ModuleNotFoundError: importlib_metadata". Pin it so it can never disappear.
+importlib_metadata==8.7.1
 
 # Supabase integration
 supabase==2.11.0  # For state management and caching

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -1,0 +1,106 @@
+# =============================================================================
+# requirements.lock.txt — FULLY PINNED dependency lockfile (DO NOT hand-edit)
+# =============================================================================
+# This is the complete transitive closure of requirements.lightweight.txt,
+# pinned to the exact versions of the known-good production image
+# (v12, digest sha256:314b86fa..., Python 3.11.14). The Docker image installs
+# from THIS file so rebuilds are deterministic and reproduce a bootable env.
+#
+# Why this exists: requirements.lightweight.txt pins only direct deps. On
+# 2026-06-10 a fresh rebuild let pip re-resolve transitive deps and dropped
+# `importlib_metadata` (pulled in by the opentelemetry stack behind logfire),
+# crash-looping the app on boot with `ModuleNotFoundError: importlib_metadata`.
+# Pinning the full closure here prevents that drift.
+#
+# To regenerate after changing requirements.lightweight.txt:
+#   1. Build a clean image from requirements.lightweight.txt (Python 3.11-slim)
+#   2. Run `python -m pip freeze` inside it
+#   3. Verify the app boots (import src.main / GET /health returns 200)
+#   4. Replace the pins below with the verified freeze, keeping this header
+# =============================================================================
+aiohappyeyeballs==2.6.1
+aiohttp==3.13.3
+aiosignal==1.4.0
+annotated-types==0.7.0
+anyio==4.12.1
+asyncio==3.4.3
+attrs==25.4.0
+beautifulsoup4==4.12.3
+cachetools==6.2.4
+certifi==2026.1.4
+charset-normalizer==3.4.4
+click==8.3.1
+cssselect==1.3.0
+cssutils==2.11.1
+deprecation==2.1.0
+distro==1.9.0
+executing==2.2.1
+fastapi==0.115.6
+frozenlist==1.8.0
+googleapis-common-protos==1.72.0
+gotrue==2.12.4
+h11==0.16.0
+h2==4.3.0
+hpack==4.1.0
+httpcore==1.0.9
+httptools==0.7.1
+httpx==0.28.1
+hyperframe==6.1.0
+idna==3.11
+importlib_metadata==8.7.1
+iniconfig==2.3.0
+Jinja2==3.1.6
+jiter==0.12.0
+logfire==2.8.0
+lxml==5.3.0
+markdown-it-py==4.0.0
+MarkupSafe==3.0.3
+mdurl==0.1.2
+more-itertools==10.8.0
+multidict==6.7.0
+openai==1.82.0
+opentelemetry-api==1.39.1
+opentelemetry-exporter-otlp-proto-common==1.39.1
+opentelemetry-exporter-otlp-proto-http==1.39.1
+opentelemetry-instrumentation==0.60b1
+opentelemetry-proto==1.39.1
+opentelemetry-sdk==1.39.1
+opentelemetry-semantic-conventions==0.60b1
+packaging==25.0
+pluggy==1.6.0
+postgrest==0.19.3
+premailer==3.10.0
+propcache==0.4.1
+protobuf==6.33.4
+pydantic==2.10.6
+pydantic-settings==2.7.1
+pydantic_core==2.27.2
+Pygments==2.19.2
+PyJWT==2.10.1
+pytest==9.0.2
+python-dateutil==2.9.0.post0
+python-dotenv==1.2.1
+python-multipart==0.0.20
+PyYAML==6.0.3
+realtime==2.0.0
+requests==2.32.5
+rich==14.2.0
+six==1.17.0
+sniffio==1.3.1
+soupsieve==2.8.2
+starlette==0.41.3
+storage3==0.11.3
+StrEnum==0.4.15
+supabase==2.11.0
+supafunc==0.9.4
+tenacity==9.0.0
+tqdm==4.67.1
+typing_extensions==4.12.2
+urllib3==2.6.3
+uvicorn==0.34.0
+uvloop==0.22.1
+watchfiles==1.1.1
+websockets==12.0
+wrapt==1.17.3
+yarl==1.22.0
+zipp==3.23.0


### PR DESCRIPTION
## Why

On 2026-06-10 a fresh `fly deploy` crash-looped the backend on boot with `ModuleNotFoundError: No module named 'importlib_metadata'`. The image hadn't been rebuilt since v12 (Jan 18); `requirements.lightweight.txt` pinned only direct deps, so when pip re-resolved the transitive closure it dropped `importlib_metadata` (pulled in by the `opentelemetry` stack behind `logfire`). Result: any rebuild was a gamble — the app couldn't be safely redeployed at all.

## What this does

- **`requirements.lock.txt` (new)** — the full pinned transitive closure (86 pkgs), captured via `pip freeze` from the **known-good v12 image** so it reproduces a proven-bootable env (not a fresh, broken resolve). Includes `importlib_metadata==8.7.1` + the pinned `opentelemetry==1.39.1` stack.
- **`Dockerfile`** — installs from `requirements.lock.txt` for deterministic rebuilds.
- **`requirements.lightweight.txt`** — kept as the human-edited direct-deps source; documents the lock relationship and adds an explicit `importlib_metadata==8.7.1` drift guard.
- **`fly.toml`** — warm machine (`auto_stop_machines=false`, `min_machines_running=1`) so the daily digest run isn't auto-stopped mid-flight. (Already live in prod since 2026-06-10; this commits the config to match.)

## Regenerating the lock later

Edit `requirements.lightweight.txt`, then: build clean from it → `pip freeze` → verify `/health` 200 → replace the pins in the lock.

## Verification

- Local build from the new Dockerfile → boot → `/health` 200 `{"status":"healthy","version":"2.1.0"}`.
- **Already deployed to prod (2026-06-12):** full from-scratch `fly deploy` rebuilt clean, machine on new image (v15), no `ModuleNotFoundError`, no restart loop; live `paperboy-ai.fly.dev/health` → 200. This is **post-hoc review** — the change is already running in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)