### PR TITLE
Add Fireworks LLM provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Configuration is loaded from `config/.env` (see `config/.env.example`).
 
 ### Required
 
-- `OPENAI_API_KEY`: OpenAI API key
+- `OPENAI_API_KEY`: OpenAI API key (required when `LLM_PROVIDER` is unset/`openai`; not required when `LLM_PROVIDER=fireworks`, which uses `FIREWORKS_API_KEY` instead — see [LLM provider](#llm-provider-openai-or-fireworks))
 - `API_KEY`: required for authenticated endpoints via `X-API-Key`
 - `SUPABASE_URL`, `SUPABASE_KEY`: used for task state + caching (required by the current implementation)
 
@@ -64,6 +64,22 @@ Configuration is loaded from `config/.env` (see `config/.env.example`).
 - `NEWSAPI_KEY` (required only if `NEWS_ENABLED=true` and you want news results)
 - `TAVILY_API_KEY` (optional, improves news article extraction)
 - `LOGFIRE_TOKEN` (optional)
+
+### LLM provider (OpenAI or Fireworks)
+
+LLM workloads run through an OpenAI-compatible client and default to OpenAI.
+To run on [Fireworks AI](https://fireworks.ai) instead, set:
+
+- `LLM_PROVIDER`: `openai` (default) or `fireworks`
+- `LLM_API_MODE` (optional): `responses` or `chat_completions`. Unset uses the
+  provider default (`responses` for OpenAI, `chat_completions` for Fireworks).
+- `FIREWORKS_API_KEY`: required when `LLM_PROVIDER=fireworks`
+- `FIREWORKS_MODEL` (default: `accounts/fireworks/models/llama-v3p1-70b-instruct`)
+- `FIREWORKS_BASE_URL` (default: `https://api.fireworks.ai/inference/v1`)
+
+OpenAI remains the fallback/default and its behavior is unchanged. See
+[docs/fireworks-migration.md](docs/fireworks-migration.md) for safe rollout
+guardrails and what to compare in evals.
 
 ## API
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,11 +1,31 @@
 # .env.example
 # Copy this file to .env and fill in your OpenAI API key.
 
-# OpenAI API key (required)
+# OpenAI API key (required when LLM_PROVIDER=openai, which is the default)
 OPENAI_API_KEY=your-openai-api-key-here  # Get this from https://platform.openai.com/api-keys
 
 # OpenAI model to use (optional, defaults to gpt-4.1-2025-04-14)
 OPENAI_MODEL=gpt-4.1-mini-2025-04-14
+
+# ---------------------------------------------------------------------------
+# LLM provider selection (OpenAI-compatible)
+# ---------------------------------------------------------------------------
+# Which backend to use for LLM workloads. Both providers use the OpenAI client.
+#   openai    -> uses OPENAI_API_KEY / OPENAI_MODEL (default)
+#   fireworks -> uses FIREWORKS_API_KEY / FIREWORKS_MODEL / FIREWORKS_BASE_URL
+LLM_PROVIDER=openai
+
+# API surface to call. Leave unset to use the provider default:
+#   openai    -> responses
+#   fireworks -> chat_completions
+# Override only if a provider/model needs a specific surface.
+#   responses | chat_completions
+# LLM_API_MODE=
+
+# Fireworks AI (only needed when LLM_PROVIDER=fireworks). Do NOT commit a real key.
+# FIREWORKS_API_KEY=your-fireworks-api-key-here
+# FIREWORKS_MODEL=accounts/fireworks/models/llama-v3p1-70b-instruct
+# FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1
 
 # Path to arXiv data file (optional, defaults to arxiv_cs_submissions_2025-04-01.json)
 ARXIV_FILE=arxiv_cs_submissions_2025-04-01.json

--- a/docs/fireworks-migration.md
+++ b/docs/fireworks-migration.md
@@ -1,0 +1,94 @@
+# Running Paperboy on Fireworks AI
+
+Paperboy can run its LLM workloads (ranking, analysis, summarization, digest
+generation) on [Fireworks AI](https://fireworks.ai) through Fireworks'
+OpenAI-compatible API. OpenAI remains the default and fallback — switching is a
+configuration change only, with no code edits required.
+
+## How it works
+
+`LLMClient` talks to both providers through the same `AsyncOpenAI` client. Only
+four things differ per provider, all driven by config:
+
+| Setting        | OpenAI                       | Fireworks                                              |
+| -------------- | ---------------------------- | ------------------------------------------------------ |
+| API key        | `OPENAI_API_KEY`             | `FIREWORKS_API_KEY`                                    |
+| Base URL       | (default OpenAI)             | `FIREWORKS_BASE_URL` (`https://api.fireworks.ai/inference/v1`) |
+| Model          | `OPENAI_MODEL`               | `FIREWORKS_MODEL` (e.g. `accounts/fireworks/models/llama-v3p1-70b-instruct`) |
+| Default API mode | `responses`                | `chat_completions`                                     |
+
+Fireworks does not implement OpenAI's Responses API, so the client defaults to
+**chat completions** for Fireworks. You can force a surface with `LLM_API_MODE`
+if a specific model needs it.
+
+If `LLM_PROVIDER=fireworks` but `FIREWORKS_API_KEY` is unset, the client fails
+fast at construction with a clear error rather than making a doomed call. API
+keys are never logged — only provider, model, and API mode are emitted.
+
+## Configuration
+
+Add to `config/.env` (see `config/.env.example`):
+
+```bash
+LLM_PROVIDER=fireworks
+FIREWORKS_API_KEY=fw-...                 # do not commit a real key
+FIREWORKS_MODEL=accounts/fireworks/models/llama-v3p1-70b-instruct
+FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1
+# LLM_API_MODE=chat_completions          # optional; this is the Fireworks default
+```
+
+To revert to OpenAI, set `LLM_PROVIDER=openai` (or remove the line). No other
+change is needed.
+
+A Fireworks-only deployment does **not** need `OPENAI_API_KEY` at all —
+`OPENAI_API_KEY` is only required when `LLM_PROVIDER` is unset or `openai`.
+Startup validation enforces the key for whichever provider is selected, so a
+missing key fails fast with a clear error.
+
+## Pre-start guardrails (safety)
+
+Before pointing Paperboy at Fireworks for anything beyond a smoke test:
+
+- **Public / synthetic data only.** Use arXiv abstracts, NewsAPI articles, and
+  synthetic user profiles. Do not send private or customer data to a new
+  provider while evaluating it.
+- **Keep contexts separate.** This change is scoped to the Paperboy app. Do not
+  reuse keys, models, or data from other projects.
+- **Secrets stay out of git.** Provide `FIREWORKS_API_KEY` via environment /
+  secret manager, never hardcoded or committed.
+- **Verify the swap before trusting output.** Run the smoke harness:
+
+  ```bash
+  LLM_PROVIDER=fireworks FIREWORKS_API_KEY=... \
+    python3 scripts/eval_provider_smoke.py
+  ```
+
+  It runs a tiny synthetic ranking task and skips cleanly (exit 0) when no key
+  is present, so it is safe in CI.
+
+## What to compare in evals (OpenAI vs Fireworks)
+
+Run the same fixture inputs through both providers and compare:
+
+1. **JSON validity** — share of ranking/analysis responses that parse and pass
+   Pydantic validation on the first attempt (i.e. without hitting the manual
+   fallback path). Chat-completions models are more likely to wrap JSON in code
+   fences; the client strips fences, but track first-pass validity anyway.
+2. **Ranking quality** — for a fixed synthetic article set + user profile, do
+   the top-N selections and relevance scores look sensible and stable? Spot-check
+   `score_reason` for relevance to the stated goals.
+3. **Latency** — wall-clock per call (the smoke harness prints elapsed time).
+   Compare p50/p95 over several runs.
+4. **Cost** — per-1K-token pricing × tokens used per digest. Fireworks open
+   models are typically cheaper; confirm against your actual digest sizes.
+5. **Retry / error rate** — frequency of retries (the client retries 3x with
+   exponential backoff) and terminal failures. A provider that needs frequent
+   retries erodes any latency/cost advantage.
+
+## Notes
+
+- Structured output uses prompt-based JSON (schema embedded in the system
+  prompt) plus Pydantic validation and a manual-parse fallback. This path is
+  provider-agnostic and works for both Responses and Chat Completions.
+- The retry/backoff, caching, and circuit-breaker behavior are unchanged by the
+  provider swap.

--- a/scripts/eval_provider_smoke.py
+++ b/scripts/eval_provider_smoke.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Tiny, fixture-only smoke harness for the configured LLM provider.
+
+Exercises ``LLMClient.rank_articles`` against a small SYNTHETIC ranking task so
+you can sanity-check a provider swap (OpenAI <-> Fireworks) end to end.
+
+Safety guardrails:
+- Uses only synthetic, public-shaped fixture data. No customer data, ever.
+- Skips cleanly (exit 0) when the selected provider has no API key configured,
+  so it is safe to run in CI or locally without credentials.
+- Performs a real API call ONLY when a key is present. It does not hardcode any
+  secret; credentials come from the environment / config.
+
+Usage:
+    # OpenAI (default)
+    python3 scripts/eval_provider_smoke.py
+
+    # Fireworks
+    LLM_PROVIDER=fireworks FIREWORKS_API_KEY=... \
+        FIREWORKS_MODEL=accounts/fireworks/models/llama-v3p1-70b-instruct \
+        python3 scripts/eval_provider_smoke.py
+"""
+import asyncio
+import os
+import sys
+import time
+
+# Allow running from the repo root without installing the package.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Synthetic fixtures — entirely fabricated, no real users or sources.
+SYNTHETIC_ARTICLES = [
+    {
+        "title": "Efficient Attention Mechanisms for Long-Context Transformers",
+        "authors": ["A. Researcher", "B. Scientist"],
+        "subject": "cs.LG",
+        "abstract_url": "https://arxiv.org/abs/0000.00001",
+        "type": "paper",
+    },
+    {
+        "title": "A Survey of Vector Databases for Retrieval-Augmented Generation",
+        "authors": ["C. Author"],
+        "subject": "cs.IR",
+        "abstract_url": "https://arxiv.org/abs/0000.00002",
+        "type": "paper",
+    },
+    {
+        "title": "Open-Source LLM Inference Gets 3x Cheaper",
+        "authors": ["Synthetic Newsroom"],
+        "subject": "news",
+        "abstract_url": "https://example.com/news/llm-inference",
+        "type": "news",
+    },
+]
+
+SYNTHETIC_USER = {
+    "name": "Test User",
+    "title": "ML Engineer",
+    "goals": "retrieval-augmented generation and efficient LLM inference",
+}
+
+
+def _provider_has_credentials() -> bool:
+    from src.config import settings
+
+    provider = (settings.llm_provider or "openai").lower()
+    if provider == "fireworks":
+        return bool(settings.fireworks_api_key)
+    if provider == "openai":
+        return bool(settings.openai_api_key and settings.openai_api_key != "test-openai-key")
+    return False
+
+
+async def _run() -> int:
+    from src.config import settings
+    from src.llm_client import LLMClient
+
+    provider = (settings.llm_provider or "openai").lower()
+
+    if not _provider_has_credentials():
+        print(f"[skip] No usable credentials for provider '{provider}'. "
+              "Set the provider API key to run a live smoke test.")
+        return 0
+
+    client = LLMClient()
+    print(f"[info] provider={client.provider} model={client.model} "
+          f"api_mode={client.api_mode}")
+
+    start = time.time()
+    try:
+        ranked = await client.rank_articles(
+            list(SYNTHETIC_ARTICLES), dict(SYNTHETIC_USER), top_n=2
+        )
+    except Exception as exc:  # noqa: BLE001 - smoke harness reports any failure
+        print(f"[fail] ranking call raised: {type(exc).__name__}: {exc}")
+        return 1
+    elapsed = time.time() - start
+
+    if not ranked:
+        print(f"[fail] ranking returned no articles ({elapsed:.2f}s)")
+        return 1
+
+    print(f"[ok] ranked {len(ranked)} articles in {elapsed:.2f}s")
+    for art in ranked:
+        print(f"  - {art.relevance_score:>3}  {art.title}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_run()))

--- a/src/config.py
+++ b/src/config.py
@@ -9,8 +9,42 @@ class Settings(BaseSettings):
     All values are loaded from environment variables (or config/.env) with type safety.
     Missing mandatory fields will raise validation errors at startup.
     """
-    openai_api_key: str = Field(..., validation_alias='OPENAI_API_KEY')
+    # OpenAI key is no longer required at import time so a Fireworks-only
+    # deployment can start without it. LLMClient enforces its presence when
+    # LLM_PROVIDER=openai (the default), failing fast with a clear error.
+    openai_api_key: Optional[str] = Field(default=None, validation_alias='OPENAI_API_KEY')
     openai_model: str = Field(default='gpt-4o', validation_alias='OPENAI_MODEL')
+
+    # LLM provider selection (OpenAI-compatible). Keep OpenAI as the default.
+    llm_provider: str = Field(
+        default='openai',
+        validation_alias='LLM_PROVIDER',
+        description="Which LLM backend to use: 'openai' or 'fireworks'. Both use the OpenAI-compatible client.",
+    )
+    # API surface to call. When unset, the client picks a provider-appropriate
+    # default: 'responses' for OpenAI, 'chat_completions' for Fireworks.
+    llm_api_mode: Optional[str] = Field(
+        default=None,
+        validation_alias='LLM_API_MODE',
+        description="LLM API surface: 'responses' or 'chat_completions'. Unset = provider default.",
+    )
+
+    # Fireworks AI (OpenAI-compatible endpoints). Only required when LLM_PROVIDER=fireworks.
+    fireworks_api_key: Optional[str] = Field(
+        default=None,
+        validation_alias='FIREWORKS_API_KEY',
+        description="Fireworks AI API key. Required only when LLM_PROVIDER=fireworks.",
+    )
+    fireworks_model: str = Field(
+        default='accounts/fireworks/models/llama-v3p1-70b-instruct',
+        validation_alias='FIREWORKS_MODEL',
+        description="Fireworks model id. Override with the model you want to evaluate.",
+    )
+    fireworks_base_url: str = Field(
+        default='https://api.fireworks.ai/inference/v1',
+        validation_alias='FIREWORKS_BASE_URL',
+        description="Fireworks OpenAI-compatible base URL.",
+    )
     top_n_articles: int = Field(default=5, validation_alias='TOP_N_ARTICLES')
     top_n_news: int = Field(default=5, validation_alias='TOP_N_NEWS', description="Number of news articles to include in digest")
     ranking_input_max_articles: int = Field(default=20, validation_alias='RANKING_INPUT_MAX_ARTICLES', description="Maximum number of raw articles to send to the LLM for the ranking step.")

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -46,8 +46,112 @@ class LLMClient:
     """Simple LLM client with retry logic and structured outputs."""
 
     def __init__(self):
-        self.client = AsyncOpenAI(api_key=settings.openai_api_key)
-        self.model = settings.openai_model
+        """Build an OpenAI-compatible client for the configured provider.
+
+        Both OpenAI and Fireworks are reached through ``AsyncOpenAI``; only the
+        api_key, base_url, model, and default API surface differ. OpenAI remains
+        the default and its behavior is unchanged.
+        """
+        provider = (settings.llm_provider or "openai").lower()
+        self.provider = provider
+
+        if provider == "openai":
+            if not settings.openai_api_key:
+                raise ValueError(
+                    "LLM_PROVIDER=openai (default) but OPENAI_API_KEY is not set. "
+                    "Set OPENAI_API_KEY, or switch LLM_PROVIDER to 'fireworks' and "
+                    "set FIREWORKS_API_KEY."
+                )
+            api_key = settings.openai_api_key
+            base_url: Optional[str] = None
+            self.model = settings.openai_model
+            default_api_mode = "responses"
+        elif provider == "fireworks":
+            if not settings.fireworks_api_key:
+                raise ValueError(
+                    "LLM_PROVIDER=fireworks but FIREWORKS_API_KEY is not set. "
+                    "Set FIREWORKS_API_KEY, or switch LLM_PROVIDER back to 'openai'."
+                )
+            api_key = settings.fireworks_api_key
+            base_url = settings.fireworks_base_url
+            self.model = settings.fireworks_model
+            default_api_mode = "chat_completions"
+        else:
+            raise ValueError(
+                f"Unsupported LLM_PROVIDER '{provider}'. Use 'openai' or 'fireworks'."
+            )
+
+        # Resolve API surface: explicit override wins, else provider default.
+        api_mode = (settings.llm_api_mode or default_api_mode).lower()
+        if api_mode not in ("responses", "chat_completions"):
+            raise ValueError(
+                f"Unsupported LLM_API_MODE '{api_mode}'. Use 'responses' or 'chat_completions'."
+            )
+        self.api_mode = api_mode
+
+        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = AsyncOpenAI(**client_kwargs)
+
+        # Log provider/model/mode but NEVER the API key.
+        logfire.info(
+            "LLMClient initialized",
+            extra={
+                "provider": self.provider,
+                "model": self.model,
+                "api_mode": self.api_mode,
+            },
+        )
+
+    @staticmethod
+    def _strip_code_fences(content: str) -> str:
+        """Remove leading/trailing markdown code fences from a model response."""
+        if not content:
+            return content
+        content = content.strip()
+        if content.startswith("```json"):
+            content = content[7:]
+        elif content.startswith("```html"):
+            content = content[7:]
+        elif content.startswith("```"):
+            content = content[3:]
+        if content.endswith("```"):
+            content = content[:-3]
+        return content.strip()
+
+    async def _raw_completion(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        temperature: float,
+    ) -> str:
+        """Issue a single completion via the configured API surface and return raw text.
+
+        - ``responses`` (OpenAI default): combine prompts into one input and read
+          ``output_text``.
+        - ``chat_completions`` (Fireworks default / OpenAI-compatible): send
+          system + user messages and read ``choices[0].message.content``.
+        """
+        if self.api_mode == "chat_completions":
+            response = await self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=temperature,
+            )
+            return response.choices[0].message.content
+
+        # Default: Responses API. Combine system and user prompts.
+        input_content = f"{system_prompt}\n\n{user_prompt}"
+        response = await self.client.responses.create(
+            model=self.model,
+            input=input_content,
+            temperature=temperature,
+        )
+        return response.output_text
 
     @retry(
         stop=stop_after_attempt(3),
@@ -60,22 +164,14 @@ class LLMClient:
         temperature: float = 0.7,
         max_tokens: int = 4000
     ) -> str:
-        """Make LLM call with retry logic and performance monitoring using Responses API."""
+        """Make LLM call with retry logic and performance monitoring."""
         start_time = time.time()
         try:
-            # Format input for Responses API - combine system and user prompts
-            input_content = f"{system_prompt}\n\n{user_prompt}"
-            
-            response = await self.client.responses.create(
-                model=self.model,
-                input=input_content,
-                temperature=temperature
-            )
-            
-            # Extract content using output_text property (simplified)
-            content = response.output_text
+            content = await self._raw_completion(system_prompt, user_prompt, temperature)
+
+            # Extract content (simplified)
             if not content:
-                raise ValueError("Empty response from OpenAI")
+                raise ValueError(f"Empty response from {self.provider}")
 
             # Remove markdown code blocks if present
             if content.startswith("```json"):
@@ -117,21 +213,24 @@ class LLMClient:
         start_time = time.time()
         
         try:
-            # Use Responses API with JSON schema instruction
-            combined_prompt = f"{system_prompt}\n\nYou must respond with valid JSON matching this schema: {response_model.model_json_schema()}\n\n{user_prompt}"
-            
-            response = await self.client.responses.create(
-                model=self.model,
-                input=combined_prompt,
-                temperature=temperature
+            # Prompt for JSON matching the schema. Works across both API surfaces;
+            # the schema instruction lives in the system prompt so chat_completions
+            # keeps a clean user message.
+            structured_system_prompt = (
+                f"{system_prompt}\n\nYou must respond with valid JSON matching "
+                f"this schema: {response_model.model_json_schema()}"
             )
-            
+
             # Get response text and parse JSON
-            json_text = response.output_text
+            json_text = await self._raw_completion(
+                structured_system_prompt, user_prompt, temperature
+            )
             if not json_text:
-                raise ValueError("Empty response from OpenAI")
+                raise ValueError(f"Empty response from {self.provider}")
                 
             try:
+                # Strip markdown code fences (common with chat_completions models)
+                json_text = self._strip_code_fences(json_text)
                 # Parse JSON and validate with Pydantic model
                 json_data = json.loads(json_text)
                 parsed_content = response_model(**json_data)

--- a/src/main.py
+++ b/src/main.py
@@ -70,7 +70,20 @@ def get_supabase_client() -> Client:
 
 def validate_environment():
     """Validate required environment variables at startup."""
-    required_vars = ['OPENAI_API_KEY', 'API_KEY']
+    # API_KEY is always required for endpoint authentication. The LLM provider
+    # key requirement depends on LLM_PROVIDER (default 'openai').
+    required_vars = ['API_KEY']
+
+    provider = os.getenv('LLM_PROVIDER', 'openai').lower()
+    if provider == 'openai':
+        required_vars.append('OPENAI_API_KEY')
+    elif provider == 'fireworks':
+        required_vars.append('FIREWORKS_API_KEY')
+    else:
+        raise RuntimeError(
+            f"Unsupported LLM_PROVIDER '{provider}'. Use 'openai' or 'fireworks'."
+        )
+
     missing = [var for var in required_vars if not os.getenv(var)]
     if missing:
         raise RuntimeError(f"Missing required environment variables: {missing}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Shared pytest fixtures and environment bootstrap.
+
+``src.config`` instantiates a ``Settings()`` singleton at import time and
+requires ``OPENAI_API_KEY``. Set synthetic env vars BEFORE any src import so
+collection never touches real credentials or external services.
+"""
+import os
+
+# Synthetic, non-secret defaults. Never real keys.
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
+os.environ.setdefault("API_KEY", "test-api-key")
+os.environ.setdefault("NEWS_ENABLED", "false")

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,216 @@
+"""Tests for provider selection and API-surface handling in LLMClient.
+
+These tests never call a real API: ``AsyncOpenAI`` is replaced with a fake that
+records constructor kwargs and returns canned responses. They cover:
+
+- OpenAI default behavior (Responses API) is preserved.
+- Fireworks selection wires api_key/base_url/model and defaults to
+  chat_completions.
+- Fireworks without a key fails fast with a clear error.
+- chat_completions extraction reads ``choices[0].message.content``.
+- LLM_API_MODE override is honored.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import src.config as config_module
+from src import llm_client as llm_module
+from src.llm_client import LLMClient
+
+
+# --------------------------------------------------------------------------
+# Fakes for the OpenAI-compatible async client
+# --------------------------------------------------------------------------
+class _FakeResponses:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    async def create(self, **kwargs):
+        self._recorder["responses_calls"].append(kwargs)
+        return SimpleNamespace(output_text='{"articles": []}')
+
+
+class _FakeChatCompletions:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    async def create(self, **kwargs):
+        self._recorder["chat_calls"].append(kwargs)
+        message = SimpleNamespace(content='{"articles": []}')
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class FakeAsyncOpenAI:
+    """Records constructor kwargs and exposes fake responses/chat endpoints."""
+
+    last_init_kwargs = None
+
+    def __init__(self, **kwargs):
+        FakeAsyncOpenAI.last_init_kwargs = kwargs
+        self.recorder = {"responses_calls": [], "chat_calls": []}
+        self.responses = _FakeResponses(self.recorder)
+        self.chat = SimpleNamespace(completions=_FakeChatCompletions(self.recorder))
+
+
+@pytest.fixture
+def fake_openai(monkeypatch):
+    """Patch AsyncOpenAI in the llm_client module with the recording fake."""
+    FakeAsyncOpenAI.last_init_kwargs = None
+    monkeypatch.setattr(llm_module, "AsyncOpenAI", FakeAsyncOpenAI)
+    return FakeAsyncOpenAI
+
+
+def _set_provider(monkeypatch, **overrides):
+    """Override fields on the live settings singleton for the duration of a test."""
+    for name, value in overrides.items():
+        monkeypatch.setattr(config_module.settings, name, value, raising=False)
+
+
+# --------------------------------------------------------------------------
+# Provider selection
+# --------------------------------------------------------------------------
+def test_openai_provider_defaults(fake_openai, monkeypatch):
+    _set_provider(
+        monkeypatch,
+        llm_provider="openai",
+        llm_api_mode=None,
+        openai_api_key="sk-openai",
+        openai_model="gpt-4o",
+    )
+
+    client = LLMClient()
+
+    assert client.provider == "openai"
+    assert client.model == "gpt-4o"
+    assert client.api_mode == "responses"  # OpenAI default surface
+    assert fake_openai.last_init_kwargs == {"api_key": "sk-openai"}
+    # No base_url override for OpenAI.
+    assert "base_url" not in fake_openai.last_init_kwargs
+
+
+def test_fireworks_provider_wires_base_url_and_model(fake_openai, monkeypatch):
+    _set_provider(
+        monkeypatch,
+        llm_provider="fireworks",
+        llm_api_mode=None,
+        fireworks_api_key="fw-secret",
+        fireworks_model="accounts/fireworks/models/llama-v3p1-70b-instruct",
+        fireworks_base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    client = LLMClient()
+
+    assert client.provider == "fireworks"
+    assert client.model == "accounts/fireworks/models/llama-v3p1-70b-instruct"
+    assert client.api_mode == "chat_completions"  # Fireworks default surface
+    assert fake_openai.last_init_kwargs["api_key"] == "fw-secret"
+    assert fake_openai.last_init_kwargs["base_url"] == "https://api.fireworks.ai/inference/v1"
+
+
+def test_fireworks_without_key_fails_fast(fake_openai, monkeypatch):
+    _set_provider(
+        monkeypatch,
+        llm_provider="fireworks",
+        llm_api_mode=None,
+        fireworks_api_key=None,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        LLMClient()
+
+    assert "FIREWORKS_API_KEY" in str(excinfo.value)
+
+
+def test_openai_without_key_fails_fast(fake_openai, monkeypatch):
+    _set_provider(
+        monkeypatch,
+        llm_provider="openai",
+        llm_api_mode=None,
+        openai_api_key=None,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        LLMClient()
+
+    assert "OPENAI_API_KEY" in str(excinfo.value)
+
+
+def test_unsupported_provider_raises(fake_openai, monkeypatch):
+    _set_provider(monkeypatch, llm_provider="anthropic", llm_api_mode=None)
+    with pytest.raises(ValueError):
+        LLMClient()
+
+
+def test_api_mode_override_honored(fake_openai, monkeypatch):
+    # Force OpenAI to use chat_completions explicitly.
+    _set_provider(
+        monkeypatch,
+        llm_provider="openai",
+        llm_api_mode="chat_completions",
+        openai_api_key="sk-openai",
+        openai_model="gpt-4o",
+    )
+    client = LLMClient()
+    assert client.api_mode == "chat_completions"
+
+
+def test_invalid_api_mode_raises(fake_openai, monkeypatch):
+    _set_provider(
+        monkeypatch,
+        llm_provider="openai",
+        llm_api_mode="grpc",
+        openai_api_key="sk-openai",
+    )
+    with pytest.raises(ValueError):
+        LLMClient()
+
+
+# --------------------------------------------------------------------------
+# Extraction paths
+# --------------------------------------------------------------------------
+def test_chat_completions_extraction(fake_openai, monkeypatch):
+    _set_provider(
+        monkeypatch,
+        llm_provider="fireworks",
+        llm_api_mode=None,
+        fireworks_api_key="fw-secret",
+    )
+    client = LLMClient()
+
+    async def fake_create(**kwargs):
+        message = SimpleNamespace(content="hello from fireworks")
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    monkeypatch.setattr(client.client.chat.completions, "create", fake_create)
+
+    result = asyncio.run(client._raw_completion("sys", "user", 0.3))
+    assert result == "hello from fireworks"
+
+
+def test_responses_extraction(fake_openai, monkeypatch):
+    _set_provider(
+        monkeypatch,
+        llm_provider="openai",
+        llm_api_mode=None,
+        openai_api_key="sk-openai",
+    )
+    client = LLMClient()
+
+    async def fake_create(**kwargs):
+        # Responses API combines system+user into a single input string.
+        assert "sys" in kwargs["input"] and "user" in kwargs["input"]
+        return SimpleNamespace(output_text="hello from openai")
+
+    monkeypatch.setattr(client.client.responses, "create", fake_create)
+
+    result = asyncio.run(client._raw_completion("sys", "user", 0.3))
+    assert result == "hello from openai"
+
+
+def test_strip_code_fences():
+    assert LLMClient._strip_code_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
+    assert LLMClient._strip_code_fences('```\nplain\n```') == "plain"
+    assert LLMClient._strip_code_fences('{"a": 1}') == '{"a": 1}'
+    assert LLMClient._strip_code_fences("") == ""

--- a/tests/test_validate_environment.py
+++ b/tests/test_validate_environment.py
@@ -1,0 +1,70 @@
+"""Tests for provider-specific startup validation in ``validate_environment``.
+
+These never start the app or touch a real service; they only exercise the
+environment-variable checks. ``API_KEY`` is always required; the LLM key
+requirement depends on ``LLM_PROVIDER`` (default ``openai``).
+"""
+import pytest
+
+from src.main import validate_environment
+
+
+def _clear_llm_env(monkeypatch):
+    """Start from a clean slate for the vars this function inspects."""
+    for var in ("LLM_PROVIDER", "OPENAI_API_KEY", "FIREWORKS_API_KEY", "API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    # Supabase disabled so the function doesn't wander into that branch.
+    monkeypatch.setenv("USE_SUPABASE", "false")
+
+
+def test_openai_default_requires_openai_key(monkeypatch):
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("API_KEY", "k")
+    # LLM_PROVIDER unset -> defaults to openai, OPENAI_API_KEY missing.
+    with pytest.raises(RuntimeError) as excinfo:
+        validate_environment()
+    assert "OPENAI_API_KEY" in str(excinfo.value)
+
+
+def test_openai_default_passes_with_openai_key(monkeypatch):
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    validate_environment()  # should not raise
+
+
+def test_fireworks_requires_fireworks_key(monkeypatch):
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("LLM_PROVIDER", "fireworks")
+    # No FIREWORKS_API_KEY set.
+    with pytest.raises(RuntimeError) as excinfo:
+        validate_environment()
+    assert "FIREWORKS_API_KEY" in str(excinfo.value)
+
+
+def test_fireworks_passes_without_openai_key(monkeypatch):
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("LLM_PROVIDER", "fireworks")
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw-secret")
+    # Notably OPENAI_API_KEY is absent and this must still pass.
+    validate_environment()  # should not raise
+
+
+def test_unknown_provider_raises(monkeypatch):
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    with pytest.raises(RuntimeError) as excinfo:
+        validate_environment()
+    assert "anthropic" in str(excinfo.value)
+
+
+def test_missing_api_key_reported(monkeypatch):
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    # API_KEY missing.
+    with pytest.raises(RuntimeError) as excinfo:
+        validate_environment()
+    assert "API_KEY" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Add config-driven LLM provider selection for `openai` (default) or `fireworks`
- Route Paperboy LLM calls through provider-specific OpenAI-compatible client settings and API surfaces
- Keep OpenAI Responses API behavior as the default; default Fireworks to chat completions for compatibility
- Add a synthetic-data smoke harness and Fireworks migration runbook/eval criteria
- Add mock-only pytest coverage for provider wiring, API-mode extraction, fail-fast key validation, and startup env validation

## Safety / scope
- No real Fireworks API call was made
- No secrets or customer data added
- Paperboy remains OpenAI-compatible by default; Fireworks is opt-in via env vars
- Fireworks-only config no longer requires `OPENAI_API_KEY`; selected-provider key validation happens at startup and `LLMClient` construction

## Verification
- ✅ `python3 -m py_compile src/config.py src/llm_client.py src/main.py scripts/eval_provider_smoke.py tests/conftest.py tests/test_llm_provider.py tests/test_validate_environment.py`
- ✅ `git diff --check`
- ✅ `/tmp/paperboy-venv/bin/python -m pytest -q` → `16 passed, 1 skipped, 5 warnings`
- ✅ `env -u OPENAI_API_KEY -u FIREWORKS_API_KEY /tmp/paperboy-venv/bin/python scripts/eval_provider_smoke.py` skips cleanly without credentials
- ✅ `env -u OPENAI_API_KEY -u FIREWORKS_API_KEY LLM_PROVIDER=fireworks /tmp/paperboy-venv/bin/python scripts/eval_provider_smoke.py` skips cleanly without credentials

## Notes
- Test warnings are dependency/pre-existing: pydantic `min_items`/`max_items` deprecation, supabase/gotrue deprecation, and Logfire-not-configured warning in tests.
- Fireworks model default is a placeholder/eval default; choose the actual model before running a live eval.
- Obsidian learnings note: `/root/obsidian/99_Hermes/Interview Prep/2026-06-18 - Paperboy Fireworks Migration Learnings.md`

## Decision / assumption
Decision: Paperboy is the right pre-start Fireworks product-fluency workload; Pennie/Twilio/customer workflows stay out of scope. Assumption: no live Fireworks API calls until Noah provides/uses a personal Fireworks key and explicitly wants eval results.
