### PR TITLE
Feed news_interest into article analysis prompt

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -623,6 +623,8 @@ Focus on:
 2. How it directly impacts their daily work
 3. What specific action they should take
 
+If the user has stated topic/news interests, frame relevance around those interests too — not only their primary goals.
+
 Your response MUST be **only** a valid JSON object structured exactly as follows:
 
 {
@@ -646,6 +648,7 @@ Do not include any other text outside of this JSON structure."""
         user_prompt = f"""User Name: {user_info.get('name', 'Researcher')}
 User Title: {user_info.get('title', 'Researcher')}
 User Research Goals: {user_info.get('goals', ', '.join(user_info.get('research_interests', [])))}
+{f"User Topic/News Interests: {user_info.get('news_interest')}" if user_info.get('news_interest') else ""}
 
 Article Title: {article_metadata.get('title', 'N/A')}
 Article Authors: {', '.join(article_metadata.get('authors', []))}


### PR DESCRIPTION
## What

`analyze_article` produces the per-item **"Why this matters" / `importance` / `relevance_to_user`** copy in each digest. It only received `name`/`title`/`goals` — never `news_interest` — so the explanation layer always framed items through the user's primary goals, even when their stated topic interests were the reason an item was selected.

This:
- passes `news_interest` into the analysis user prompt, and
- adds a system-prompt line telling the model to frame relevance around stated interests too, not only goals.

Falsy-guarded, so profiles without interests are unaffected.

## Why now

n8n workflow 2 was just updated to forward `profiles.interests` → `user_info.news_interest` (previously always null), so the ranking step now personalizes news selection. A manual test digest confirmed news *selection* reflects interests, but the *explanation* copy still defaulted to goals — this closes that gap.

## Scope / contract

- Same shared `user_info` contract (`UserContext`: name/title/goals/news_interest) — no schema or DB change.
- Affects only generated text. No deploy-time behavior change beyond the prompt.

## Verify

- `python3 -m py_compile src/llm_client.py` ✅
- After deploy: trigger a digest for a profile with `interests` set and confirm the news items' "Why this matters" copy references those interests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)