### PR TITLE
fix(llm): handle Fireworks gpt-oss empty content; bound chat max_tokens

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -142,6 +142,7 @@ class LLMClient:
         system_prompt: str,
         user_prompt: str,
         temperature: float,
+        max_tokens: int = 8000,
     ) -> str:
         """Issue a single completion via the configured API surface and return raw text.
 
@@ -158,6 +159,8 @@ class LLMClient:
                     {"role": "user", "content": user_prompt},
                 ],
                 temperature=temperature,
+                # reasoning models (gpt-oss) spend budget on CoT; unbounded -> empty content
+                max_tokens=max_tokens,
             )
             return self._extract_chat_content(response)
 
@@ -191,8 +194,14 @@ class LLMClient:
             raise ValueError(f"{self.provider} chat response choice had no message")
 
         content = getattr(message, "content", None)
-        if content is None:
-            raise ValueError(f"{self.provider} chat response had message.content=None")
+        if content is None or (isinstance(content, str) and not content.strip()):
+            # Reasoning models (e.g. Fireworks gpt-oss) may leave content empty and
+            # put the answer in reasoning_content. ponytail: best-effort fallback;
+            # if it isn't valid JSON, the caller's manual-parse path handles it.
+            reasoning = getattr(message, "reasoning_content", None)
+            if reasoning and str(reasoning).strip():
+                return str(reasoning)
+            raise ValueError(f"{self.provider} chat response had empty message.content and no reasoning_content")
 
         if isinstance(content, str):
             return content
@@ -236,7 +245,7 @@ class LLMClient:
         """Make LLM call with retry logic and performance monitoring."""
         start_time = time.time()
         try:
-            content = await self._raw_completion(system_prompt, user_prompt, temperature)
+            content = await self._raw_completion(system_prompt, user_prompt, temperature, max_tokens=max_tokens)
 
             # Extract content (simplified)
             if not content:
@@ -292,7 +301,7 @@ class LLMClient:
 
             # Get response text and parse JSON
             json_text = await self._raw_completion(
-                structured_system_prompt, user_prompt, temperature
+                structured_system_prompt, user_prompt, temperature, max_tokens=8000
             )
             if not json_text:
                 raise ValueError(f"Empty response from {self.provider}")

--- a/tests/test_extract_chat_content.py
+++ b/tests/test_extract_chat_content.py
@@ -1,0 +1,52 @@
+"""Focused tests for the reasoning_content fallback in _extract_chat_content.
+
+Fireworks reasoning models (e.g. gpt-oss-120b) may return message.content as
+None or empty while putting the actual answer in message.reasoning_content.
+_extract_chat_content must fall back to reasoning_content instead of failing
+(which previously opened the circuit breaker and degraded every digest).
+
+These exercise _extract_chat_content directly with SimpleNamespace stubs; no
+network or AsyncOpenAI mocking is needed since the method only reads
+self.provider and the response shape.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from src.llm_client import LLMClient
+
+
+def _client():
+    """Build an LLMClient without running __init__ (only self.provider is used)."""
+    client = LLMClient.__new__(LLMClient)
+    client.provider = "fireworks"
+    return client
+
+
+def _response(content, reasoning_content=None):
+    if reasoning_content is None:
+        message = SimpleNamespace(content=content)
+    else:
+        message = SimpleNamespace(content=content, reasoning_content=reasoning_content)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def test_content_none_falls_back_to_reasoning_content():
+    resp = _response(None, reasoning_content="the answer")
+    assert _client()._extract_chat_content(resp) == "the answer"
+
+
+def test_empty_content_falls_back_to_reasoning_content():
+    resp = _response("   ", reasoning_content="the answer")
+    assert _client()._extract_chat_content(resp) == "the answer"
+
+
+def test_both_empty_raises_valueerror():
+    resp = _response(None, reasoning_content="")
+    with pytest.raises(ValueError):
+        _client()._extract_chat_content(resp)
+
+
+def test_normal_content_returned_unchanged():
+    resp = _response("normal text")
+    assert _client()._extract_chat_content(resp) == "normal text"

--- a/tests/test_llm_client_hardening.py
+++ b/tests/test_llm_client_hardening.py
@@ -46,7 +46,7 @@ def _chat_response(content):
 def test_content_none_raises_clear_valueerror(chat_client):
     with pytest.raises(ValueError) as excinfo:
         chat_client._extract_chat_content(_chat_response(None))
-    assert "content=None" in str(excinfo.value)
+    assert "empty message.content and no reasoning_content" in str(excinfo.value)
     assert not isinstance(excinfo.value, AttributeError)
 
 


### PR DESCRIPTION
## Root cause

Prod was switched to Fireworks `gpt-oss-120b` (a **reasoning** model) reached through the `chat_completions` API path. Reasoning models return their answer differently, and the chat path made it worse:

- The chat path sent **NO `max_tokens`**. The model spent its entire (unbounded-but-capped-by-default) budget on chain-of-thought reasoning and never emitted the final JSON answer. The answer text ends up in `message.reasoning_content` while `message.content` comes back `None`/empty.
- `_extract_chat_content` treated `content=None`/empty as a hard failure. Historically this surfaced as an `AttributeError` (`.strip()` on `None`); after prior hardening it became a `ValueError`. Either way it raised, and via `tenacity` retries this **trips the circuit breaker**, so every user's digest degrades or fails.

## Fix (minimal, `src/llm_client.py` only)

1. `_raw_completion`: add `max_tokens: int = 8000` and pass it into the `chat.completions.create(...)` call so reasoning models have room to finish the answer. The `responses` path (OpenAI) is left unchanged.
2. `_call_llm`: forward its own `max_tokens` (it was being dropped).
3. `_call_llm_structured`: pass a generous `max_tokens=8000` for ranking JSON.
4. `_extract_chat_content`: when `content` is `None`/empty, fall back to `message.reasoning_content` before raising. If that text isn't valid JSON, the caller's existing manual-parse fallback handles it.

Adds `tests/test_extract_chat_content.py` exercising the fallback directly (content=None→reasoning, empty content→reasoning, both empty→ValueError, normal content unchanged). All pass.

## NOT in this PR (follow-ups)

- Cap oversized ranking payloads that cause intermittent `400 Bad Request` from the provider.
- The circuit breaker is keyed `"openai"` while the active provider is `fireworks` — cosmetic/labeling only, not behavior-affecting.

## Immediate ops mitigation

To restore digests **right now**, flip `LLM_PROVIDER` back to `openai` on Fly app `paperboy-ai`. OpenAI uses the unaffected `responses` path and is not impacted by this bug. This PR is the durable fix so Fireworks `gpt-oss` can be used safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)