### PR TITLE
fix: prevent Fireworks digest timeout failures

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -37,6 +37,11 @@ ANALYSIS_CONTENT_MAX_CHARS=20000
 
 RANKING_INPUT_MAX_ARTICLES=30
 
+# Timeout controls. DIGEST_TASK_TIMEOUT is separate from TASK_TIMEOUT so slow
+# LLM-backed digest generation is not capped by stale fetch-task secrets.
+TASK_TIMEOUT=600
+DIGEST_TASK_TIMEOUT=900
+
 # API key for Paperboy Endpoints
 API_KEY=
 

--- a/fly.toml
+++ b/fly.toml
@@ -39,6 +39,7 @@ primary_region = "ord"  # Change to your preferred region
   TOP_N_ARTICLES = "5"
   TOP_N_NEWS = "5"
   TASK_TIMEOUT = "600"
+  DIGEST_TASK_TIMEOUT = "900"
   HTTP_TIMEOUT = "60"
   NEWS_MAX_ARTICLES = "50"
   NEWS_MAX_EXTRACT = "10"

--- a/src/config.py
+++ b/src/config.py
@@ -106,7 +106,8 @@ class Settings(BaseSettings):
     news_metrics_enabled: bool = Field(default=True, validation_alias='NEWS_METRICS_ENABLED')
     
     # Timeout configuration (critical for preventing timeouts)
-    task_timeout: int = Field(default=600, validation_alias='TASK_TIMEOUT', description="Max time for digest generation in seconds")
+    task_timeout: int = Field(default=600, validation_alias='TASK_TIMEOUT', description="Max time for fetch tasks in seconds")
+    digest_task_timeout: int = Field(default=900, validation_alias='DIGEST_TASK_TIMEOUT', description="Max time for digest generation in seconds (independent of TASK_TIMEOUT, which can be a stale Fly secret)")
     request_timeout: int = Field(default=595, validation_alias='REQUEST_TIMEOUT', description="HTTP request timeout for API endpoints")
     http_timeout: int = Field(default=60, validation_alias='HTTP_TIMEOUT', description="General HTTP client timeout")
     

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from .circuit_breaker import ServiceCircuitBreakers
 from .graceful_shutdown import GracefulShutdown, RequestTracker
 from .fetch_service import FetchSourcesService, DailySourcesManager
 from . import observability
+from .http_utils import send_webhook_callback
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -263,16 +264,36 @@ async def timeout_middleware(request: Request, call_next):
 async def safe_background_task(task_id: str, *args, **kwargs):
     """Wrapper for background tasks with timeout and error handling."""
     try:
-        task_timeout = settings.task_timeout
+        # Dedicated digest timeout, independent of TASK_TIMEOUT (used by fetch
+        # tasks and prone to going stale in Fly secrets).
+        task_timeout = settings.digest_task_timeout
         # Use asyncio.timeout for Python 3.11+
         async with asyncio.timeout(task_timeout):
             await app.state.digest_service.generate_digest(task_id, *args, **kwargs)
     except asyncio.TimeoutError:
+        message = f"Task timeout after {task_timeout} seconds"
         await app.state.state_manager.update_task(
             task_id,
-            DigestStatus(status=TaskStatus.FAILED, message="Task timeout")
+            DigestStatus(status=TaskStatus.FAILED, message=message)
         )
         logger.error(f"Task {task_id} timed out after {task_timeout} seconds")
+        # generate_digest add_task args = (user_info, callback_url, ...); notify
+        # the caller (n8n) of the failure instead of leaving it waiting.
+        callback_url = args[1] if len(args) > 1 else None
+        if callback_url:
+            try:
+                await send_webhook_callback(callback_url, task_id, "failed", message)
+            except Exception as callback_error:
+                observability.capture_exception(
+                    callback_error,
+                    stage="background_task_timeout_callback",
+                    task_id=task_id,
+                )
+                logger.exception(
+                    "Failed to send timeout callback for task %s: %s",
+                    task_id,
+                    callback_error,
+                )
     except Exception as e:
         observability.capture_exception(e, stage="background_task", task_id=task_id)
         await app.state.state_manager.update_task(

--- a/tests/test_digest_timeout.py
+++ b/tests/test_digest_timeout.py
@@ -1,0 +1,83 @@
+"""Regression tests for digest background-task timeout handling.
+
+Incident on 2026-06-25: 27/50 digests failed with "Task timeout" at ~300s
+because safe_background_task used settings.task_timeout, which was a stale Fly
+secret (300) overriding fly.toml. Digest generation now uses a dedicated
+settings.digest_task_timeout (default 900) and, on timeout, notifies the caller
+via a failed webhook callback instead of leaving n8n waiting.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import src.main as main
+from src.config import settings
+from src.models import TaskStatus
+
+
+@pytest.fixture
+def app_state(monkeypatch):
+    state = SimpleNamespace(
+        digest_service=SimpleNamespace(generate_digest=AsyncMock()),
+        state_manager=SimpleNamespace(update_task=AsyncMock()),
+    )
+    monkeypatch.setattr(main.app, "state", state)
+    return state
+
+
+def test_digest_timeout_uses_dedicated_setting_not_task_timeout(app_state, monkeypatch):
+    """Capture the timeout value passed to asyncio.timeout; it must be the
+    dedicated digest_task_timeout, not the (stale) task_timeout."""
+    monkeypatch.setattr(settings, "task_timeout", 300)
+    monkeypatch.setattr(settings, "digest_task_timeout", 900)
+
+    captured = {}
+    real_timeout = asyncio.timeout
+    monkeypatch.setattr(
+        main.asyncio, "timeout",
+        lambda value: captured.__setitem__("value", value) or real_timeout(value),
+    )
+
+    asyncio.run(main.safe_background_task("task-1", {"name": "x"}, None))
+
+    assert captured["value"] == 900
+
+
+def test_timeout_marks_failed_and_sends_callback(app_state, monkeypatch):
+    """On timeout: task marked FAILED with timeout-seconds message + failed callback."""
+    monkeypatch.setattr(settings, "digest_task_timeout", 900)
+    app_state.digest_service.generate_digest = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    sent = AsyncMock()
+    monkeypatch.setattr(main, "send_webhook_callback", sent)
+
+    callback_url = "https://n8n.example.com/hook"
+    asyncio.run(main.safe_background_task("task-2", {"name": "x"}, callback_url))
+
+    # Task updated as failed with the configured timeout in the message.
+    app_state.state_manager.update_task.assert_awaited_once()
+    _, status = app_state.state_manager.update_task.await_args.args
+    assert status.status == TaskStatus.FAILED
+    assert "900 seconds" in status.message
+
+    # Caller notified of the failure.
+    sent.assert_awaited_once()
+    args = sent.await_args.args
+    assert args[0] == callback_url
+    assert args[1] == "task-2"
+    assert args[2] == "failed"
+
+
+def test_timeout_without_callback_url_does_not_send(app_state, monkeypatch):
+    monkeypatch.setattr(settings, "digest_task_timeout", 900)
+    app_state.digest_service.generate_digest = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    sent = AsyncMock()
+    monkeypatch.setattr(main, "send_webhook_callback", sent)
+
+    asyncio.run(main.safe_background_task("task-3", {"name": "x"}, None))
+
+    app_state.state_manager.update_task.assert_awaited_once()
+    sent.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes the remaining Paperboy digest failures after PRs #20/#21 by separating the long-running digest timeout from the generic/fetch timeout.

## Investigation evidence

- Fly `paperboy-ai` is deployed at version 20 / commit `6a05a41` (PR #21 merged and deployed).
- Fly runtime env is `LLM_PROVIDER=fireworks`, `FIREWORKS_MODEL=accounts/fireworks/models/gpt-oss-120b`.
- Fly still has a `TASK_TIMEOUT=300` secret, which overrides `fly.toml`'s `TASK_TIMEOUT = "600"`.
- Supabase `digest_tasks` for 2026-06-25 showed `50` digest tasks: `23 completed`, `27 failed`.
- Every failed digest had message `Task timeout` and duration ~`300.1–300.5s`.
- Completed digest durations were close to the same ceiling: min `190s`, p50 `261s`, p90 `291s`, max `294s`.

Conclusion: PR #21 resolved the Fireworks response-shape failure, but production digests are now slow enough that the stale 300-second Fly secret kills many otherwise-progressing jobs.

## Changes

- Add `DIGEST_TASK_TIMEOUT` with a safe default of `900` seconds.
- Keep `TASK_TIMEOUT` for fetch tasks, so source fetching remains separately bounded.
- Update digest background task handling to use `settings.digest_task_timeout` instead of `settings.task_timeout`.
- Improve timeout task message to `Task timeout after <seconds> seconds`.
- Send a failed webhook callback to n8n on digest timeout when a `callback_url` exists, so orchestration gets a semantic failure instead of silent waiting/drop behavior.
- Document `DIGEST_TASK_TIMEOUT` in `fly.toml` and `.env.example`.
- Add regression tests for the dedicated timeout and timeout callback behavior.

## Verification

```bash
/root/github_repos/ventures/paperboy_all/paperboy/.venv/bin/python -m pytest tests/test_digest_timeout.py -v
# 3 passed, 4 warnings

/root/github_repos/ventures/paperboy_all/paperboy/.venv/bin/python -m pytest tests/test_digest_timeout.py tests/test_ranking_fallback.py tests/test_llm_client_hardening.py tests/test_validate_environment.py -q
# 23 passed, 5 warnings

/root/github_repos/ventures/paperboy_all/paperboy/.venv/bin/python -m py_compile src/config.py src/main.py tests/test_digest_timeout.py
# success

git diff --check
# success
```

Warnings are pre-existing dependency/deprecation/logfire warnings from the local venv.

## Deployment notes

No deploy performed in this PR. After merge, deploy to Fly. Because `DIGEST_TASK_TIMEOUT` is new and not currently a secret, the `fly.toml` env value should apply on deploy.

Optional cleanup after deploy: remove or raise the stale `TASK_TIMEOUT=300` Fly secret so fetch tasks are not unexpectedly capped at 300s. This PR makes digest generation immune to that stale secret, but it intentionally leaves fetch tasks governed by `TASK_TIMEOUT`.

## Residual risk

This raises the failure ceiling; it does not speed up Fireworks generation. If digest durations continue creeping toward 900s, the next fix should optimize the prompt/ranking/summary workload or switch providers for the daily run.
