### PR TITLE
fix: stop Logfire warning calls breaking email templates

### DIFF
--- a/src/email_renderer.py
+++ b/src/email_renderer.py
@@ -54,7 +54,7 @@ def _inline_css_if_enabled(html: str) -> str:
         return transform(html)
     except Exception as e:
         # If inlining fails, fall back to raw HTML.
-        logfire.warning(f"CSS inlining failed, returning non-inlined HTML: {e}")
+        logfire.warn(f"CSS inlining failed, returning non-inlined HTML: {e}")
         return html
 
 

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -320,7 +320,7 @@ class LLMClient:
                 raise ValueError(f"Pydantic validation failed: {str(e)}")
                 
         except Exception as e:
-            logfire.warning(f"Structured output failed: {str(e)}")
+            logfire.warn(f"Structured output failed: {str(e)}")
             
             if fallback_to_manual:
                 logfire.info("Falling back to manual JSON parsing")
@@ -997,7 +997,7 @@ Content:
         
         # Log if we had to fix the date
         if correct_date not in html:
-            logfire.warning(f"LLM generated incorrect date, fixed to: {correct_date}")
+            logfire.warn(f"LLM generated incorrect date, fixed to: {correct_date}")
         
         return html
 
@@ -1290,7 +1290,7 @@ Create a cohesive HTML digest that tells a story about what's important for this
             cleaned_html = self._fix_date_in_html(cleaned_html, current_date)
 
             if not cleaned_html:
-                logfire.warning("Empty HTML response from LLM, using fallback")
+                logfire.warn("Empty HTML response from LLM, using fallback")
                 return self._create_fallback_html(summaries, user_info)
 
             return cleaned_html
@@ -1420,7 +1420,7 @@ Focus: {user_info.get('goals', 'Research')}"""
                 return highlights[:max_highlights]
 
         except Exception as e:
-            logfire.warning(f"LLM highlight generation failed, using fallback: {str(e)}")
+            logfire.warn(f"LLM highlight generation failed, using fallback: {str(e)}")
 
         # Deterministic fallback: extract from summaries directly
         highlights = []
@@ -1543,7 +1543,7 @@ Focus: {user_info.get('goals', 'Research')}"""
                     type=content_type
                 ))
             except Exception as e:
-                logfire.warning(f"Failed to create HighlightItem: {e}")
+                logfire.warn(f"Failed to create HighlightItem: {e}")
                 continue
 
         return DigestEmailData(

--- a/tests/test_logfire_warning_compat.py
+++ b/tests/test_logfire_warning_compat.py
@@ -1,0 +1,80 @@
+"""Regression tests for Logfire warning API compatibility.
+
+Production Logfire exposes ``warn`` but not ``warning``. A prior use of
+``logfire.warning`` in the Python email-template path caused template rendering
+to raise and fall back to LLM-generated HTML.
+"""
+import ast
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import src.config as config_module
+from src import llm_client as llm_module
+from src.llm_client import LLMClient
+
+
+class _FakeAsyncOpenAI:
+    def __init__(self, **kwargs):
+        self.responses = None
+        self.chat = None
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(llm_module, "AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr(config_module.settings, "llm_provider", "fireworks", raising=False)
+    monkeypatch.setattr(config_module.settings, "fireworks_api_key", "fw-test", raising=False)
+    return LLMClient()
+
+
+def test_no_logfire_warning_calls_in_src():
+    """Guard against the production AttributeError: logfire.warning missing."""
+    src_dir = Path(__file__).resolve().parents[1] / "src"
+    offenders = []
+    for path in src_dir.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr == "warning"
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "logfire"
+            ):
+                offenders.append(f"{path.relative_to(src_dir.parent)}:{node.lineno}")
+
+    assert offenders == []
+
+
+def test_create_digest_data_highlight_fallback_does_not_break_template_path(client, monkeypatch):
+    """Invalid highlight JSON should fall back deterministically, not raise."""
+
+    async def invalid_json(*args, **kwargs):
+        return "not json"
+
+    monkeypatch.setattr(client, "_call_llm", invalid_json)
+
+    summaries = [
+        {
+            "title": "Graph-Based Phonetic Error Correction of Noisy ASR",
+            "type": "paper",
+            "relevance_score": 96,
+            "summary": "A graph-based ASR correction method.",
+            "why_relevant": "Improves speech recognition reliability.",
+            "key_takeaway": "Can improve noisy transcripts without heavy model overhead.",
+            "abstract_url": "https://arxiv.org/abs/1234.5678",
+            "pdf_url": "https://arxiv.org/pdf/1234.5678",
+        }
+    ]
+
+    digest = asyncio.run(
+        client.create_digest_data(
+            summaries,
+            {"name": "Noah Mogil", "title": "Solutions Engineer", "goals": "Voice AI"},
+        )
+    )
+
+    assert digest.user_name == "Noah Mogil"
+    assert digest.highlights
+    assert digest.directly_relevant[0].title == summaries[0]["title"]


### PR DESCRIPTION
## Summary

Fixes today's Paperboy digest using fallback/LLM formatting instead of the Jinja2 email template.

## Root cause

Production logs showed the backend entering the template path and then immediately falling back:

```text
Using Python email templates (Jinja2) for digest rendering
Template rendering failed, falling back to LLM: module 'logfire' has no attribute 'warning'
Using LLM-based HTML generation for digest
```

The screenshot matched that fallback output: correct content, but plain `PAPERBOY DIGEST` styling instead of the designed template.

The actual bug: some code used `logfire.warning(...)`, but the installed production Logfire package exposes `logfire.warn(...)` and does not have `warning`. When highlight generation or CSS inlining hit a warning path, the logging call itself raised `AttributeError`, which made the whole Jinja2 template render path look failed and forced the LLM fallback renderer.

## Changes

- Replace all `logfire.warning(...)` calls in `src/llm_client.py` and `src/email_renderer.py` with `logfire.warn(...)`.
- Add regression coverage to guard against future `logfire.warning` calls in `src`.
- Add a template-path regression test showing invalid highlight JSON falls back deterministically and still builds `DigestEmailData` instead of breaking the template path.

## Verification

```bash
.venv/bin/python - <<'PY'
import logfire
print('has_warn', hasattr(logfire, 'warn'))
print('has_warning', hasattr(logfire, 'warning'))
PY
# has_warn True
# has_warning False

.venv/bin/python -m pytest tests/test_logfire_warning_compat.py tests/test_digest_timeout.py tests/test_ranking_fallback.py tests/test_llm_client_hardening.py tests/test_validate_environment.py -q
# 25 passed, 5 warnings

.venv/bin/python -m py_compile src/llm_client.py src/email_renderer.py tests/test_logfire_warning_compat.py
# success

git diff --check
# success
```

Warnings are pre-existing local dependency/deprecation/logfire-no-config warnings.

## Deployment note

After merge, deploy to Fly. The change is small and directly targets the observed production exception.
