### PR TITLE
fix: bound ranking prompts and normalize news URLs

### DIFF
--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -28,6 +28,28 @@ def summarize_exception(exc: BaseException) -> str:
         return "RetryError with no recorded cause"
     return f"{type(exc).__name__}: {exc}"
 
+
+def cap_ranking_input(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Cap the candidate list before it is serialized into a ranking prompt.
+
+    The source-separated paths (rank_papers_only / rank_news_only) used to send
+    the full daily corpus (646 papers on 2026-06-27) to the LLM, blowing past
+    the model context window (141k > 131k tokens -> Fireworks 400). Enforcing the
+    same RANKING_INPUT_MAX_ARTICLES cap that the mixed path already uses keeps
+    every caller safe.
+
+    This is a deterministic article-count cap, not a token estimator. Papers and
+    news are bounded and roughly uniform in size, so count is a good enough proxy
+    for budget; switch to a char/token estimate here if item sizes ever vary wildly.
+    """
+    max_articles = settings.ranking_input_max_articles
+    if len(items) > max_articles:
+        logfire.info(
+            f"Capping ranking input from {len(items)} to {max_articles} items"
+        )
+        return items[:max_articles]
+    return items
+
 # Structured output schemas for ranking
 class ArticleRanking(BaseModel):
     """Schema for complete ranked article in structured output - matches RankedArticle structure."""
@@ -275,6 +297,10 @@ class LLMClient:
                 "temperature": temperature
             })
 
+    # TODO: a context-length 400 (prompt too long) is not retryable — retrying it
+    # 3x just wastes time and quota. cap_ranking_input() now prevents oversized
+    # prompts upstream, so this is rare; add a retry_if_exception predicate that
+    # skips non-retryable BadRequest errors if it ever recurs.
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10)
@@ -410,6 +436,8 @@ Articles:
         top_n: int
     ) -> List[RankedArticle]:
         """Rank research papers separately based on user profile."""
+        # Cap candidates before serialization so the prompt stays within context.
+        papers = cap_ranking_input(papers)
         # Normalize author field to authors list before processing (safety check)
         for paper in papers:
             if 'author' in paper and 'authors' not in paper:
@@ -468,6 +496,8 @@ Papers:
         top_n: int
     ) -> List[RankedArticle]:
         """Rank news articles separately based on user profile."""
+        # Cap candidates before serialization so the prompt stays within context.
+        news_articles = cap_ranking_input(news_articles)
         # Normalize author field to authors list before processing
         for article in news_articles:
             if 'author' in article and 'authors' not in article:
@@ -601,11 +631,20 @@ News Articles:
         if 'reasoning' in article_data and 'score_reason' not in article_data:
             article_data['score_reason'] = article_data.pop('reasoning')
 
+        # News items often carry 'url' instead of 'abstract_url'; without this map
+        # every news article fails RankedArticle validation -> all-sources failure.
+        if not article_data.get('abstract_url') and article_data.get('url'):
+            article_data['abstract_url'] = article_data['url']
+
         # Set or infer content type
         if content_type:
             article_data['type'] = content_type
         elif infer_type and ('type' not in article_data or not article_data['type']):
             article_data['type'] = 'news' if article_data.get('subject') == 'news' else 'paper'
+
+        # News responses frequently omit 'subject' (a required field); default it.
+        if not article_data.get('subject') and article_data.get('type') == 'news':
+            article_data['subject'] = 'news'
 
     async def rank_mixed_content(
         self,

--- a/tests/test_ranking_budget.py
+++ b/tests/test_ranking_budget.py
@@ -1,0 +1,105 @@
+"""Regression tests for the 2026-06-27 context-length incident.
+
+50 digests, 35 failed with Fireworks 400 "prompt is too long" (~141k > 131k
+tokens). Root cause: the source-separated ranking path
+(rank_papers_only / rank_news_only) sent the full daily corpus (646 papers) to
+the LLM, bypassing the RANKING_INPUT_MAX_ARTICLES cap the mixed path already had.
+
+Secondary bug: news items carry ``url`` not ``abstract_url``; normalization
+mapped score/reason but not the URL, so every news item failed RankedArticle
+validation and the all-sources failure followed.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import src.config as config_module
+from src import llm_client as llm_module
+from src.llm_client import LLMClient, RankingResponse
+
+
+class _FakeAsyncOpenAI:
+    def __init__(self, **kwargs):
+        self.responses = SimpleNamespace(create=None)
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=None))
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(llm_module, "AsyncOpenAI", _FakeAsyncOpenAI)
+    monkeypatch.setattr(config_module.settings, "llm_provider", "openai", raising=False)
+    monkeypatch.setattr(config_module.settings, "openai_api_key", "sk-test", raising=False)
+    monkeypatch.setattr(config_module.settings, "ranking_input_max_articles", 20, raising=False)
+    monkeypatch.setattr(config_module.settings, "ranking_delay", 0, raising=False)
+    return LLMClient()
+
+
+def _capture_prompt(client, monkeypatch):
+    """Patch the LLM call to record the user prompt and return one ranking."""
+    captured = {}
+
+    async def fake_call(system_prompt, user_prompt, response_model, **kwargs):
+        captured["user_prompt"] = user_prompt
+        return RankingResponse(articles=[{
+            "title": "x", "authors": ["a"], "subject": "cs.AI",
+            "abstract_url": "https://example.com/x",
+            "relevance_score": 50, "score_reason": "r",
+        }])
+
+    monkeypatch.setattr(client, "_call_llm_structured", fake_call)
+    return captured
+
+
+def _serialized_items(user_prompt, label):
+    """Pull the JSON array that follows e.g. 'Papers:' out of the prompt."""
+    payload = user_prompt.split(f"{label}:\n", 1)[1]
+    return json.loads(payload)
+
+
+def test_large_paper_input_is_capped_before_serialization(client, monkeypatch):
+    captured = _capture_prompt(client, monkeypatch)
+    papers = [
+        {"title": f"P{i}", "authors": ["A"], "subject": "cs.AI",
+         "abstract_url": f"https://arxiv.org/abs/{i}"}
+        for i in range(646)
+    ]
+
+    asyncio.run(client.rank_papers_only(papers, {"name": "X"}, top_n=10))
+
+    serialized = _serialized_items(captured["user_prompt"], "Papers")
+    assert len(serialized) == 20  # not 646 — the provider never sees the full corpus
+
+
+def test_large_news_input_is_capped_before_serialization(client, monkeypatch):
+    captured = _capture_prompt(client, monkeypatch)
+    news = [
+        {"title": f"N{i}", "url": f"https://news.example.com/{i}", "type": "news"}
+        for i in range(200)
+    ]
+
+    asyncio.run(client.rank_news_only(news, {"name": "X"}, top_n=10))
+
+    serialized = _serialized_items(captured["user_prompt"], "News Articles")
+    assert len(serialized) == 20
+
+
+def test_news_item_with_url_but_no_abstract_url_validates(client):
+    """A news item carrying only 'url' must normalize into a valid RankedArticle."""
+    item = {
+        "title": "Some news",
+        "authors": ["Reporter"],
+        "url": "https://news.example.com/story",  # no abstract_url
+        "relevance_score": 70,
+        "score_reason": "relevant",
+        "type": "news",
+        # no subject either
+    }
+    client._normalize_ranking_fields(item, content_type="news", infer_type=False)
+
+    from src.models import RankedArticle
+    article = RankedArticle(**item)
+    assert str(article.abstract_url) == "https://news.example.com/story"
+    assert article.subject == "news"
+    assert article.type.value == "news"


### PR DESCRIPTION
## Summary

Fixes the 2026-06-27 Paperboy digest shortfall where source-separated ranking sent the full daily paper corpus to Fireworks:

- production failures: `prompt is too long` at ~141k-142k tokens against a 131k context limit
- source set: 646 ArXiv papers + 49 news articles
- result: paper ranking failed; news ranking returned items with `url` but no `abstract_url`, so validation rejected all news and the digest failed

## Prior PR review / guardrails

Reviewed the previous fixes before changing code so this does not repeat the same mistakes:

- #20: source-level ranking fallback + RetryError unwrapping + backend observability
- #21: Fireworks `gpt-oss` empty content / `reasoning_content` handling + bounded chat `max_tokens`
- #22: `DIGEST_TASK_TIMEOUT` split from stale `TASK_TIMEOUT=300`
- #23: `logfire.warn` compatibility for template fallback

This PR intentionally stays focused: no timeout changes, no provider rewrite, no background-worker migration, and no `logfire.warning` reintroduction.

## Changes

- Add `cap_ranking_input()` to enforce `settings.ranking_input_max_articles` before ranking prompt serialization.
- Apply the cap in both source-separated entry points:
  - `rank_papers_only()`
  - `rank_news_only()`
- Normalize ranking output before strict validation:
  - `url -> abstract_url` when `abstract_url` is missing
  - default `subject='news'` for news items missing subject
- Add regression tests that reproduce the incident class:
  - 646 paper candidates serialize as 20 candidates, not 646
  - 200 news candidates serialize as 20 candidates
  - news item with `url` but no `abstract_url` validates as `RankedArticle`

## Verification

```bash
.venv/bin/python -m pytest tests/test_ranking_budget.py tests/test_ranking_fallback.py tests/test_llm_client_hardening.py -q
# 17 passed, 5 warnings

.venv/bin/python -m pytest tests -q
# 47 passed, 1 skipped, 5 warnings

.venv/bin/python -m py_compile src/llm_client.py tests/test_ranking_budget.py
# success

git diff --check
# success
```

Warnings are existing dependency/deprecation/logfire-no-config warnings.

## Claude Code review

Claude Code implemented the first pass and then performed a no-edit review of the final diff. Review verdict: `PASS`.

Non-blocking follow-up it noted: context-length 400s are still technically retryable in Tenacity, but the new upstream cap prevents this incident path. A future provider-error taxonomy PR should skip retries for non-retryable context-length errors.

## Deployment note

After merge, deploy `paperboy-ai` to Fly and verify the next daily run no longer emits context-length ranking failures. Runtime should continue using `RANKING_INPUT_MAX_ARTICLES=20` unless we intentionally tune it.
