### PR TITLE
chore: downsize Fly VM to shared-cpu-1x / 1gb

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -24,9 +24,11 @@ primary_region = "ord"  # Change to your preferred region
   #   timeout = "10s"
 
 [[vm]]
-  memory = "4gb"
+  # Downsized 2026-07: app is async I/O-bound (~50 min of work/day, mostly LLM wait);
+  # 4gb/2cpu was 4-8x oversized and, always-on, drove the June invoice spike.
+  memory = "1gb"
   cpu_kind = "shared"
-  cpus = 2
+  cpus = 1
 
 # Environment variables (non-sensitive)
 [env]


### PR DESCRIPTION
## Why

The June Fly invoice spike traces to the 2026-06-12 always-on pin (`auto_stop_machines=false`, `min_machines_running=1`, commit 1de5722). That pin is **correct and stays** — Fly's proxy auto-stops on zero active connections, which was killing BackgroundTask digests mid-run (2026-06-10 incident). The cost problem is the *size* of the machine that's now running 24/7.

Measured from `digest_tasks`: the backend does ~50 minutes of work per day (13:01–13:55 UTC, ~50 digests, avg <1 min each, mostly LLM wall-clock wait) and is idle the other ~23h. It's a pure async-I/O app — no local ML, no Playwright. 4gb/2cpu is 4–8× oversized, and the repo's own configs agree (docker-compose: 1 CPU / 1gb limit; deploy_cloudrun.sh: 512Mi).

## Change

`[[vm]]`: 4gb/2cpu → **1gb / shared-cpu-1x**. Bill goes ~$22–25/mo → ~$5.70/mo (~75% cut).

## Deploy note

Apply as a config-only scale, **not** a `fly deploy` (avoids the known importlib_metadata rebuild trap), outside the 13:00–14:00 UTC digest window:

```
fly scale vm shared-cpu-1x --memory 1024 -a paperboy-ai
```

(Mogil Ventures Fly account, noah.mogil97@gmail.com.) This PR just keeps `fly.toml` in sync so a future deploy doesn't scale back up. Watch the first daily run after; if the window stretches, bump to shared-cpu-2x (keep 1gb).

While in there: delete the stale `TASK_TIMEOUT=300` Fly secret (caused the 06-25 timeout incident; only worked around by the DIGEST_TASK_TIMEOUT split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)