### PR TITLE
Replace n8n digest workflows with backend orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,11 @@ tasks/
 # .project_resources
 
 notebooks/
-tests
+
+# Python bytecode and test caches
+__pycache__/
+*.py[cod]
+.pytest_cache/
 
 # Pipedream scripts (contain API keys)
 pipedream/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Configuration is loaded from `config/.env` (see `config/.env.example`).
 - `LOGFIRE_TOKEN` (optional)
 - `SENTRY_DSN` (optional): enables backend error reporting to Sentry. Unset = disabled (no-op). No PII is sent — `send_default_pii=False` and user/request contexts are stripped before send. Requires `sentry-sdk` (declared in requirements); if absent the backend logs a warning and stays disabled.
 - `SENTRY_ENVIRONMENT` (optional, default `production`): environment tag for Sentry events
+- `ORCHESTRATION_ENABLED` (default: `false`): enables the backend-hosted daily scheduler that replaces n8n. It requires `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, and the schema in [`docs/supabase_orchestration.sql`](docs/supabase_orchestration.sql). See the [backend orchestration rollout guide](docs/backend-orchestration.md).
 
 ### LLM provider (OpenAI or Fireworks)
 
@@ -84,6 +85,14 @@ OpenAI remains the fallback/default and its behavior is unchanged. See
 guardrails and what to compare in evals.
 
 ## API
+
+Backend orchestration adds protected `POST /admin/orchestration/run` and
+`GET /admin/orchestration/status/{source_date}` operations. They use the same
+`X-API-Key` authentication as other administrative endpoints and require
+`ORCHESTRATION_ENABLED=true`. See
+[`docs/backend-orchestration.md`](docs/backend-orchestration.md) for request
+examples, recovery behavior, and the n8n cutover plan.
+
 
 ### Authentication
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -42,6 +42,25 @@ RANKING_INPUT_MAX_ARTICLES=30
 TASK_TIMEOUT=600
 DIGEST_TASK_TIMEOUT=900
 
+# Supabase task state. Daily orchestration additionally requires a server-only
+# service-role key; never expose that key to the frontend.
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-server-task-state-key
+# SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Backend replacement for the three n8n workflows. Keep disabled until
+# docs/supabase_orchestration.sql is applied and Resend/service-role secrets are
+# installed. The scheduler processes yesterday's UTC sources at 13:00 UTC.
+ORCHESTRATION_ENABLED=false
+ORCHESTRATION_HOUR_UTC=13
+ORCHESTRATION_POLL_SECONDS=60
+ORCHESTRATION_CATCHUP_HOURS=24
+ORCHESTRATION_PROFILE_INTERVAL_SECONDS=60
+ORCHESTRATION_MAX_CONCURRENT_PROFILES=2
+ORCHESTRATION_STALE_AFTER_MINUTES=120
+# RESEND_API_KEY=your-resend-api-key
+RESEND_FROM_ADDRESS="Paperboy Digest <digest@paper-boy.app>"
+
 # API key for Paperboy Endpoints
 API_KEY=
 

--- a/docs/backend-orchestration.md
+++ b/docs/backend-orchestration.md
@@ -1,0 +1,153 @@
+# Backend daily orchestration (n8n replacement)
+
+## Goal and parity
+
+The backend can replace the three production n8n workflows without a UI or a
+second Fly.io Machine. The implementation preserves their operational contract:
+
+1. At 13:00 UTC, fetch arXiv/news sources for yesterday.
+2. Select profiles where `goals IS NOT NULL` and `remove IS NULL`.
+3. Generate one mixed digest per profile using `name`, `title`, `goals`, and
+   `interests` (forwarded as `news_interest`), with five papers and five news
+   articles.
+4. Update `profiles.task_id`, `started_at`, `task_html`, and `completed_at`.
+5. Link `digest_tasks.user_id` when the task is created, then email the rendered
+   HTML through Resend.
+
+No frontend changes are required. Existing public `/fetch-sources` and
+`/generate-digest` callback behavior remains available for other callers.
+
+## Architecture
+
+The coordinator is intentionally a small in-process module:
+
+- `orchestration.py` owns sequencing, idempotent resume behavior, pacing, and
+  per-profile failure isolation.
+- `orchestration_adapters.py` invokes the existing fetch and digest services
+  directly, avoiding HTTP calls back into the same process.
+- `orchestration_repository.py` stores run claims and delivery checkpoints in
+  Supabase using the service-role key.
+- `orchestration_scheduler.py` checks the UTC schedule from the FastAPI lifespan.
+- `resend_email.py` sends email with retries and a stable Resend idempotency key.
+- `docs/supabase_orchestration.sql` defines the backend-owned state tables and
+  atomic run-claim function.
+
+The scheduler is disabled by default. Fly already keeps exactly one app Machine
+warm, but the database claim also prevents duplicate work if the app is later
+scaled horizontally.
+
+## Durable state and recovery
+
+`orchestration_runs` has one row per source date. The SQL function
+`claim_orchestration_run` atomically allows:
+
+- the first run for a date;
+- takeover of a `running` row whose heartbeat is stale; or
+- an explicit retry of a `failed`/`completed_with_errors` row.
+
+`orchestration_deliveries` has one row per `(source_date, user_id)`, keeps an
+immutable profile snapshot so retries reuse the same recipient/content inputs,
+and moves through:
+
+```text
+pending -> generating -> generated -> sending -> sent
+                         \-> failed      \-> ambiguous
+```
+
+A restart or explicit retry behaves as follows:
+
+- `sent`: skip permanently;
+- completed `task_id`: reuse its HTML and resume profile/email delivery;
+- incomplete or missing task: create a new task;
+- email retry within 23 hours: reuse both the task and
+  `paperboy:{date}:{user_id}` Resend idempotency key;
+- an ambiguous provider receipt older than 23 hours: do not resend
+  automatically, because Resend's 24-hour key may have expired; expose it for
+  operator reconciliation instead.
+
+A single profile failure is recorded and the batch continues. Source fetch
+failure stops the batch before any profile is processed. Run and delivery claim
+IDs fence workers that wake after a stale-run takeover.
+
+## Runtime controls
+
+All administrative routes require the existing `X-API-Key` header:
+
+```http
+POST /admin/orchestration/run
+Content-Type: application/json
+
+{"source_date":"2026-07-09","retry_failed":false}
+```
+
+The request returns `202` immediately. The database claim determines whether it
+actually runs. Use `retry_failed: true` only to retry a failed/partial date; sent
+users remain skipped.
+
+```http
+GET /admin/orchestration/status/2026-07-09
+```
+
+## Configuration
+
+Required before enabling:
+
+- `SUPABASE_SERVICE_ROLE_KEY`: server-only access to protected profile rows;
+- `RESEND_API_KEY`: Resend bearer token;
+- existing `SUPABASE_URL`, `SUPABASE_KEY`, API, LLM, and news credentials.
+
+Settings:
+
+| Variable | Default | Purpose |
+| --- | ---: | --- |
+| `ORCHESTRATION_ENABLED` | `false` | Start the scheduler and enable admin operations |
+| `ORCHESTRATION_HOUR_UTC` | `13` | Daily UTC start hour |
+| `ORCHESTRATION_POLL_SECONDS` | `60` | Due-date check interval |
+| `ORCHESTRATION_CATCHUP_HOURS` | `24` | Maximum automatic missed-slot catch-up age |
+| `ORCHESTRATION_PROFILE_INTERVAL_SECONDS` | `60` | Spacing between profile launches |
+| `ORCHESTRATION_MAX_CONCURRENT_PROFILES` | `2` | Bound overlapping digest generations |
+| `ORCHESTRATION_STALE_AFTER_MINUTES` | `120` | Stale run takeover threshold |
+| `RESEND_FROM_ADDRESS` | Paperboy digest address | Verified sender identity |
+
+The service refuses to start with orchestration enabled but missing the
+service-role or Resend secret.
+
+## Rollout and rollback plan
+
+No production action is part of the code PR. After review:
+
+1. Apply `docs/supabase_orchestration.sql` in the shared Supabase project.
+2. Install `SUPABASE_SERVICE_ROLE_KEY` and `RESEND_API_KEY` as Fly secrets.
+3. Deploy with `ORCHESTRATION_ENABLED=false` and verify `/health`.
+4. Use a non-customer test profile/date to exercise the protected manual route,
+   temporarily directing delivery to an internal address if needed.
+5. Before 13:00 UTC, disable n8n workflow `1_Fetch_Sources_Daily`, then enable
+   backend orchestration at or just after 13:00 UTC. Do not enable it earlier:
+   the 24-hour catch-up window would correctly claim the prior slot that n8n
+   already handled. Alternatively seed that prior date as `completed` first.
+   Never overlap the schedulers.
+6. Monitor the run row, delivery counts, `digest_tasks.user_id`, profile HTML,
+   and Resend delivery for one full batch.
+7. Disable the remaining n8n webhook workflows after the successful batch,
+   rotate the backend API key formerly stored there, then cancel n8n.
+
+Rollback is to set `ORCHESTRATION_ENABLED=false` and reactivate the three n8n
+workflows. Existing run/delivery rows are safe to retain and ensure a later retry
+does not resend completed deliveries.
+
+## Verification plan
+
+Automated tests cover:
+
+- successful fetch/generate/profile-link/email flow;
+- atomic duplicate-run no-op behavior at the coordinator boundary;
+- per-profile failure isolation;
+- reuse of a completed task on retry;
+- task creation with `user_id` before digest execution;
+- cached-source task completion;
+- UTC due-date calculation;
+- Resend request shape, retry, idempotency reuse, and ambiguous receipts; and
+- startup refusal when orchestration secrets are absent.
+
+Before merging, run the focused tests and the complete `pytest` suite, import the
+app in a fresh process, inspect the complete diff for secrets, and confirm PR CI.

--- a/docs/supabase_orchestration.sql
+++ b/docs/supabase_orchestration.sql
@@ -1,0 +1,229 @@
+-- Backend-owned state for replacing Paperboy's n8n workflows.
+-- Apply manually in the shared Supabase project before setting
+-- ORCHESTRATION_ENABLED=true on Fly.io.
+
+create table if not exists public.orchestration_runs (
+    source_date date primary key,
+    run_id uuid not null,
+    status text not null check (
+        status in ('running', 'completed', 'completed_with_errors', 'failed')
+    ),
+    started_at timestamptz not null default now(),
+    heartbeat_at timestamptz not null default now(),
+    completed_at timestamptz,
+    total_profiles integer not null default 0,
+    sent_count integer not null default 0,
+    failed_count integer not null default 0,
+    skipped_count integer not null default 0,
+    last_error text,
+    unique (source_date, run_id)
+);
+
+create table if not exists public.orchestration_deliveries (
+    source_date date not null,
+    run_id uuid not null,
+    profile_id uuid not null,
+    user_id uuid not null,
+    profile_snapshot jsonb not null,
+    task_id text,
+    status text not null check (
+        status in (
+            'pending', 'generating', 'generated', 'sending', 'sent', 'failed',
+            'ambiguous'
+        )
+    ),
+    email_id text,
+    email_attempted_at timestamptz,
+    email_sent_at timestamptz,
+    last_error text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    primary key (source_date, user_id),
+    foreign key (source_date, run_id)
+        references public.orchestration_runs(source_date, run_id)
+        on update cascade
+        on delete cascade
+);
+
+create index if not exists orchestration_deliveries_task_id_idx
+    on public.orchestration_deliveries(task_id)
+    where task_id is not null;
+
+alter table public.orchestration_runs enable row level security;
+alter table public.orchestration_deliveries enable row level security;
+
+-- Browser clients do not need access. The backend uses a service-role client,
+-- which bypasses RLS. Explicit revokes make that boundary visible.
+revoke all on public.orchestration_runs from anon, authenticated;
+revoke all on public.orchestration_deliveries from anon, authenticated;
+grant all on public.orchestration_runs to service_role;
+grant all on public.orchestration_deliveries to service_role;
+
+create or replace function public.claim_orchestration_run(
+    p_source_date date,
+    p_run_id uuid,
+    p_stale_before timestamptz,
+    p_retry_failed boolean default false
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    affected_rows integer;
+begin
+    insert into public.orchestration_runs (
+        source_date,
+        run_id,
+        status,
+        started_at,
+        heartbeat_at,
+        completed_at,
+        total_profiles,
+        sent_count,
+        failed_count,
+        skipped_count,
+        last_error
+    ) values (
+        p_source_date,
+        p_run_id,
+        'running',
+        now(),
+        now(),
+        null,
+        0,
+        0,
+        0,
+        0,
+        null
+    )
+    on conflict (source_date) do update
+    set run_id = excluded.run_id,
+        status = 'running',
+        started_at = now(),
+        heartbeat_at = now(),
+        completed_at = null,
+        total_profiles = 0,
+        sent_count = 0,
+        failed_count = 0,
+        skipped_count = 0,
+        last_error = null
+    where (
+        orchestration_runs.status = 'running'
+        and orchestration_runs.heartbeat_at < p_stale_before
+    ) or (
+        p_retry_failed
+        and orchestration_runs.status in ('failed', 'completed_with_errors')
+    );
+
+    get diagnostics affected_rows = row_count;
+    return affected_rows = 1;
+end;
+$$;
+
+revoke all on function public.claim_orchestration_run(
+    date, uuid, timestamptz, boolean
+) from public, anon, authenticated;
+grant execute on function public.claim_orchestration_run(
+    date, uuid, timestamptz, boolean
+) to service_role;
+
+-- Fence each delivery to the currently claimed run. A worker that wakes after
+-- its lease was taken over cannot move delivery state back to its stale run_id.
+create or replace function public.claim_orchestration_delivery(
+    p_source_date date,
+    p_run_id uuid,
+    p_profile_id uuid,
+    p_user_id uuid,
+    p_profile_snapshot jsonb
+) returns setof public.orchestration_deliveries
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not exists (
+        select 1
+        from public.orchestration_runs
+        where source_date = p_source_date
+          and run_id = p_run_id
+          and status = 'running'
+    ) then
+        return;
+    end if;
+
+    insert into public.orchestration_deliveries (
+        source_date, run_id, profile_id, user_id, profile_snapshot, status
+    ) values (
+        p_source_date, p_run_id, p_profile_id, p_user_id,
+        p_profile_snapshot, 'pending'
+    )
+    on conflict (source_date, user_id) do update
+    set run_id = excluded.run_id,
+        profile_id = excluded.profile_id,
+        updated_at = now()
+    where orchestration_deliveries.status <> 'sent';
+
+    return query
+    select *
+    from public.orchestration_deliveries
+    where source_date = p_source_date
+      and user_id = p_user_id;
+end;
+$$;
+
+revoke all on function public.claim_orchestration_delivery(
+    date, uuid, uuid, uuid, jsonb
+) from public, anon, authenticated;
+grant execute on function public.claim_orchestration_delivery(
+    date, uuid, uuid, uuid, jsonb
+) to service_role;
+
+-- Profile linkage is part of the shared frontend contract. Fence it in the
+-- same statement that verifies the active run so a stale worker cannot replace
+-- a newer task_id/task_html after takeover.
+create or replace function public.update_orchestration_profile(
+    p_source_date date,
+    p_run_id uuid,
+    p_profile_id uuid,
+    p_task_id text,
+    p_html text default null
+) returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    if not exists (
+        select 1
+        from public.orchestration_runs
+        where source_date = p_source_date
+          and run_id = p_run_id
+          and status = 'running'
+    ) then
+        return false;
+    end if;
+
+    if p_html is null then
+        update public.profiles
+        set task_id = p_task_id,
+            started_at = now()
+        where id = p_profile_id;
+    else
+        update public.profiles
+        set task_id = p_task_id,
+            task_html = p_html,
+            completed_at = now()
+        where id = p_profile_id;
+    end if;
+
+    return found;
+end;
+$$;
+
+revoke all on function public.update_orchestration_profile(
+    date, uuid, uuid, text, text
+) from public, anon, authenticated;
+grant execute on function public.update_orchestration_profile(
+    date, uuid, uuid, text, text
+) to service_role;

--- a/fly.toml
+++ b/fly.toml
@@ -3,6 +3,7 @@
 
 app = "paperboy-ai"
 primary_region = "ord"  # Change to your preferred region
+kill_timeout = "30s"  # Allow lifespan cancellation/checkpointing on deploy
 
 [build]
   # Uses the existing Dockerfile
@@ -45,6 +46,12 @@ primary_region = "ord"  # Change to your preferred region
   HTTP_TIMEOUT = "60"
   NEWS_MAX_ARTICLES = "50"
   NEWS_MAX_EXTRACT = "10"
+  # Apply docs/supabase_orchestration.sql and install the service-role +
+  # Resend secrets before enabling this during the n8n cutover.
+  ORCHESTRATION_ENABLED = "false"
+  ORCHESTRATION_HOUR_UTC = "13"
+  ORCHESTRATION_PROFILE_INTERVAL_SECONDS = "60"
+  ORCHESTRATION_MAX_CONCURRENT_PROFILES = "2"
 
 # Optional: Persistent volume for data storage
 # Uncomment if you want persistent local storage
@@ -58,6 +65,10 @@ primary_region = "ord"  # Change to your preferred region
 # - API_KEY (for authentication)
 # - SUPABASE_URL
 # - SUPABASE_KEY
+#
+# Required before ORCHESTRATION_ENABLED=true:
+# - SUPABASE_SERVICE_ROLE_KEY
+# - RESEND_API_KEY
 # 
 # Optional secrets (for news functionality):
 # - NEWSAPI_KEY

--- a/src/api_models.py
+++ b/src/api_models.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import Optional, List, Dict, Any
 from pydantic import BaseModel, HttpUrl, Field
 from .models import UserContext
@@ -53,6 +54,24 @@ class FetchSourcesResponse(BaseModel):
     message: str
     source_date: str
     status_url: Optional[str] = None
+
+class OrchestrationRunRequest(BaseModel):
+    """Request a durable daily run without a UI."""
+
+    source_date: Optional[date] = Field(
+        default=None,
+        description="Source date to process; defaults to yesterday in UTC",
+    )
+    retry_failed: bool = Field(
+        default=False,
+        description="Reclaim a failed/partial run; sent deliveries remain skipped",
+    )
+
+
+class OrchestrationRunResponse(BaseModel):
+    source_date: date
+    status: str
+
 
 class FetchStatusResponse(BaseModel):
     """Response model for checking fetch task status."""

--- a/src/config.py
+++ b/src/config.py
@@ -98,7 +98,26 @@ class Settings(BaseSettings):
     supabase_url: Optional[str] = Field(None, validation_alias='SUPABASE_URL')
     supabase_key: Optional[str] = Field(None, validation_alias='SUPABASE_KEY')
     use_supabase: bool = Field(default=True, validation_alias='USE_SUPABASE', description="Use Supabase for distributed state management (recommended for Cloud Run)")
-    
+    supabase_service_role_key: Optional[str] = Field(
+        None,
+        validation_alias='SUPABASE_SERVICE_ROLE_KEY',
+        description="Server-only Supabase key used by daily orchestration to access profiles",
+    )
+
+    # Backend-hosted daily orchestration (disabled until schema and secrets exist)
+    orchestration_enabled: bool = Field(default=False, validation_alias='ORCHESTRATION_ENABLED')
+    orchestration_hour_utc: int = Field(default=13, validation_alias='ORCHESTRATION_HOUR_UTC', ge=0, le=23)
+    orchestration_poll_seconds: float = Field(default=60, validation_alias='ORCHESTRATION_POLL_SECONDS', gt=0)
+    orchestration_catchup_hours: float = Field(default=24, validation_alias='ORCHESTRATION_CATCHUP_HOURS', gt=0)
+    orchestration_profile_interval_seconds: float = Field(default=60, validation_alias='ORCHESTRATION_PROFILE_INTERVAL_SECONDS', ge=0)
+    orchestration_max_concurrent_profiles: int = Field(default=2, validation_alias='ORCHESTRATION_MAX_CONCURRENT_PROFILES', gt=0)
+    orchestration_stale_after_minutes: int = Field(default=120, validation_alias='ORCHESTRATION_STALE_AFTER_MINUTES', gt=0)
+    resend_api_key: Optional[str] = Field(None, validation_alias='RESEND_API_KEY')
+    resend_from_address: str = Field(
+        default='Paperboy Digest <digest@paper-boy.app>',
+        validation_alias='RESEND_FROM_ADDRESS',
+    )
+
     # Caching
     news_cache_ttl: int = Field(default=3600, validation_alias='NEWS_CACHE_TTL')  # 1 hour
     

--- a/src/graceful_shutdown.py
+++ b/src/graceful_shutdown.py
@@ -41,6 +41,10 @@ class GracefulShutdown:
     async def _signal_handler(self, sig: signal.Signals) -> None:
         """Handle shutdown signal."""
         logfire.info("Received signal {signal}, initiating graceful shutdown", signal=sig.name)
+        self.initiate_shutdown()
+
+    def initiate_shutdown(self) -> None:
+        """Mark shutdown as started without replacing the server's handlers."""
         self.shutdown_event.set()
     
     @asynccontextmanager

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Request
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
+from datetime import date, datetime, timedelta, timezone
 import uuid
 import asyncio
 import logfire
@@ -13,7 +14,16 @@ import os
 from typing import Dict, Any, Optional
 from supabase import create_client, Client
 
-from .api_models import GenerateDigestRequest, GenerateDigestResponse, DigestStatusResponse, FetchSourcesRequest, FetchSourcesResponse, FetchStatusResponse
+from .api_models import (
+    DigestStatusResponse,
+    FetchSourcesRequest,
+    FetchSourcesResponse,
+    FetchStatusResponse,
+    GenerateDigestRequest,
+    GenerateDigestResponse,
+    OrchestrationRunRequest,
+    OrchestrationRunResponse,
+)
 from .digest_service_enhanced import EnhancedDigestService as DigestService
 from .models import TaskStatus, DigestStatus
 from .security import validate_api_key
@@ -27,6 +37,11 @@ from .graceful_shutdown import GracefulShutdown, RequestTracker
 from .fetch_service import FetchSourcesService, DailySourcesManager
 from . import observability
 from .http_utils import send_webhook_callback
+from .orchestration import DailyDigestOrchestrator
+from .orchestration_adapters import BackendDigestGenerator, BackendSourceFetcher
+from .orchestration_repository import SupabaseOrchestrationRepository
+from .orchestration_scheduler import DailyOrchestrationScheduler
+from .resend_email import ResendEmailSender
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -90,7 +105,26 @@ def validate_environment():
             f"Unsupported LLM_PROVIDER '{provider}'. Use 'openai' or 'fireworks'."
         )
 
+    orchestration_env = os.getenv('ORCHESTRATION_ENABLED')
+    orchestration_enabled = (
+        orchestration_env.lower() == 'true'
+        if orchestration_env is not None
+        else settings.orchestration_enabled
+    )
+    orchestration_values = {
+        'RESEND_API_KEY': os.getenv('RESEND_API_KEY') or settings.resend_api_key,
+        'SUPABASE_URL': os.getenv('SUPABASE_URL') or settings.supabase_url,
+        'SUPABASE_SERVICE_ROLE_KEY': (
+            os.getenv('SUPABASE_SERVICE_ROLE_KEY')
+            or settings.supabase_service_role_key
+        ),
+    }
+
     missing = [var for var in required_vars if not os.getenv(var)]
+    if orchestration_enabled:
+        missing.extend(
+            var for var, value in orchestration_values.items() if not value
+        )
     if missing:
         raise RuntimeError(f"Missing required environment variables: {missing}")
     
@@ -113,7 +147,8 @@ async def lifespan(app: FastAPI):
     # Initialize shutdown handler
     global SHUTDOWN_HANDLER
     SHUTDOWN_HANDLER = GracefulShutdown(timeout=int(os.getenv('SHUTDOWN_TIMEOUT', '30')))
-    SHUTDOWN_HANDLER.setup_signal_handlers()
+    # Uvicorn owns SIGTERM/SIGINT. Replacing its handlers prevents lifespan
+    # teardown from starting, so shutdown is initiated from teardown below.
     
     # Initialize Supabase state manager
     app.state.state_manager = TaskStateManager()
@@ -146,7 +181,74 @@ async def lifespan(app: FastAPI):
     app.state.digest_service.circuit_breakers = app.state.circuit_breakers
     app.state.digest_service.cache = app.state.cache
     app.state.digest_service.daily_sources_manager = app.state.daily_sources_manager
-    
+
+    # Daily orchestration is opt-in so the schema and secrets can be applied
+    # before cutover from n8n. It uses a service-role client because profiles
+    # are protected by RLS and must never be accessed with a browser key.
+    app.state.orchestrator = None
+    app.state.orchestration_repository = None
+    app.state.orchestration_client = None
+    app.state.orchestration_scheduler = None
+    app.state.orchestration_email_sender = None
+    app.state.orchestration_manual_tasks = set()
+    orchestration_scheduler_task = None
+    if settings.orchestration_enabled:
+        orchestration_client = create_client(
+            settings.supabase_url,
+            settings.supabase_service_role_key,
+        )
+        repository = SupabaseOrchestrationRepository(
+            orchestration_client,
+            stale_after_minutes=settings.orchestration_stale_after_minutes,
+        )
+        orchestration_state_manager = TaskStateManager(
+            client=orchestration_client
+        )
+        source_fetcher = BackendSourceFetcher(
+            state_manager=orchestration_state_manager,
+            fetch_service=app.state.fetch_service,
+            timeout_seconds=settings.task_timeout,
+        )
+        digest_generator = BackendDigestGenerator(
+            state_manager=orchestration_state_manager,
+            digest_service=app.state.digest_service,
+            timeout_seconds=settings.digest_task_timeout,
+        )
+        email_sender = ResendEmailSender(
+            api_key=settings.resend_api_key,
+            from_address=settings.resend_from_address,
+        )
+        orchestrator = DailyDigestOrchestrator(
+            repository=repository,
+            source_fetcher=source_fetcher,
+            digest_generator=digest_generator,
+            email_sender=email_sender,
+            profile_start_interval_seconds=(
+                settings.orchestration_profile_interval_seconds
+            ),
+            max_concurrent_profiles=(
+                settings.orchestration_max_concurrent_profiles
+            ),
+        )
+        scheduler = DailyOrchestrationScheduler(
+            orchestrator,
+            hour_utc=settings.orchestration_hour_utc,
+            poll_seconds=settings.orchestration_poll_seconds,
+            catchup_hours=settings.orchestration_catchup_hours,
+        )
+        app.state.orchestrator = orchestrator
+        app.state.orchestration_repository = repository
+        app.state.orchestration_client = orchestration_client
+        app.state.orchestration_scheduler = scheduler
+        app.state.orchestration_email_sender = email_sender
+        orchestration_scheduler_task = asyncio.create_task(
+            scheduler.run_forever(), name="daily-digest-orchestration"
+        )
+        logger.info(
+            "Backend daily orchestration enabled for %02d:00 UTC",
+            settings.orchestration_hour_utc,
+        )
+
     # Start background tasks
     cleanup_task = asyncio.create_task(cleanup_old_tasks(app))
     cache_cleanup_task = asyncio.create_task(cleanup_cache(app))
@@ -158,6 +260,8 @@ async def lifespan(app: FastAPI):
             await app.state.digest_service.fetcher.close()
         if hasattr(app.state.digest_service, 'news_fetcher'):
             await app.state.digest_service.news_fetcher.close()
+        if app.state.orchestration_email_sender:
+            await app.state.orchestration_email_sender.close()
     
     SHUTDOWN_HANDLER.register_shutdown_task(close_connections)
     
@@ -165,17 +269,28 @@ async def lifespan(app: FastAPI):
     
     # Graceful shutdown
     logger.info("Starting graceful shutdown...")
+    SHUTDOWN_HANDLER.initiate_shutdown()
+    if app.state.orchestration_scheduler:
+        app.state.orchestration_scheduler.stop()
+    orchestration_tasks_to_await = []
+    if orchestration_scheduler_task:
+        orchestration_scheduler_task.cancel()
+        orchestration_tasks_to_await.append(orchestration_scheduler_task)
+    for task in app.state.orchestration_manual_tasks:
+        task.cancel()
+        orchestration_tasks_to_await.append(task)
+    if orchestration_tasks_to_await:
+        await asyncio.gather(
+            *orchestration_tasks_to_await, return_exceptions=True
+        )
     await SHUTDOWN_HANDLER.wait_for_shutdown()
     
     # Cancel background tasks
     cleanup_task.cancel()
     cache_cleanup_task.cancel()
-    
-    try:
-        await cleanup_task
-        await cache_cleanup_task
-    except asyncio.CancelledError:
-        pass
+    await asyncio.gather(
+        cleanup_task, cache_cleanup_task, return_exceptions=True
+    )
     
     logger.info("Shutdown complete")
 
@@ -505,6 +620,63 @@ async def get_fetch_status(task_id: str) -> FetchStatusResponse:
     )
 
 
+async def _run_manual_orchestration(source_date: date, retry_failed: bool) -> None:
+    """Run a manually requested batch and retain failures in durable state."""
+    try:
+        await app.state.orchestrator.run(
+            source_date, retry_failed=retry_failed
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        observability.capture_exception(
+            exc,
+            stage="manual_orchestration",
+            source_date=source_date.isoformat(),
+        )
+        logger.exception(
+            "Manual orchestration run failed for %s", source_date.isoformat()
+        )
+
+
+@app.post(
+    "/admin/orchestration/run",
+    response_model=OrchestrationRunResponse,
+    status_code=202,
+    dependencies=[Depends(validate_api_key)],
+)
+async def run_daily_orchestration(
+    request: OrchestrationRunRequest,
+) -> OrchestrationRunResponse:
+    """Start an idempotent daily run; no n8n webhook or UI is required."""
+    if not app.state.orchestrator:
+        raise HTTPException(status_code=503, detail="Orchestration is disabled")
+    source_date = request.source_date or (
+        datetime.now(timezone.utc) - timedelta(days=1)
+    ).date()
+    task = asyncio.create_task(
+        _run_manual_orchestration(source_date, request.retry_failed),
+        name=f"manual-orchestration-{source_date.isoformat()}",
+    )
+    app.state.orchestration_manual_tasks.add(task)
+    task.add_done_callback(app.state.orchestration_manual_tasks.discard)
+    return OrchestrationRunResponse(source_date=source_date, status="accepted")
+
+
+@app.get(
+    "/admin/orchestration/status/{source_date}",
+    dependencies=[Depends(validate_api_key)],
+)
+async def get_orchestration_status(source_date: date) -> Dict[str, Any]:
+    """Return durable run progress for operational checks."""
+    if not app.state.orchestration_repository:
+        raise HTTPException(status_code=503, detail="Orchestration is disabled")
+    run = await app.state.orchestration_repository.get_run(source_date)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Orchestration run not found")
+    return run
+
+
 @app.get("/preview-new-format/{task_id}", response_class=HTMLResponse)
 async def preview_new_format(task_id: str, api_key: str = Depends(validate_api_key)):
     """Preview the newsletter format for a completed task."""
@@ -593,6 +765,23 @@ async def readiness_check():
         checks["supabase"] = f"unhealthy: {str(e)}"
         overall_healthy = False
     
+    # Check the backend-only orchestration schema when the feature is enabled.
+    if app.state.orchestration_client:
+        try:
+            for table_name in (
+                "orchestration_runs",
+                "orchestration_deliveries",
+            ):
+                app.state.orchestration_client.table(table_name).select(
+                    "source_date"
+                ).limit(1).execute()
+            checks["orchestration"] = "healthy"
+        except Exception as e:
+            checks["orchestration"] = f"unhealthy: {str(e)}"
+            overall_healthy = False
+    else:
+        checks["orchestration"] = "disabled"
+
     # Check circuit breakers if available
     if hasattr(app.state, 'circuit_breakers') and app.state.circuit_breakers:
         try:

--- a/src/orchestration.py
+++ b/src/orchestration.py
@@ -1,0 +1,354 @@
+"""Durable, backend-hosted orchestration for Paperboy's daily digest run.
+
+The orchestrator owns business sequencing while persistence, digest generation,
+source fetching, and email delivery are injected adapters. This keeps the daily
+workflow independently testable and avoids making HTTP calls back into the same
+FastAPI process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from enum import Enum
+from typing import Awaitable, Callable, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class DeliveryStatus(str, Enum):
+    PENDING = "pending"
+    GENERATING = "generating"
+    GENERATED = "generated"
+    SENDING = "sending"
+    SENT = "sent"
+    FAILED = "failed"
+    AMBIGUOUS = "ambiguous"
+
+
+class AmbiguousEmailDelivery(RuntimeError):
+    """The provider may have accepted an email but no receipt was observed."""
+
+
+@dataclass(frozen=True)
+class Profile:
+    id: str
+    user_id: str
+    email: str | None
+    name: str | None
+    title: str | None
+    goals: str
+    interests: str | None
+
+
+@dataclass(frozen=True)
+class DeliveryRecord:
+    source_date: date
+    profile_id: str
+    user_id: str
+    status: DeliveryStatus
+    task_id: str | None = None
+    email_id: str | None = None
+    email_attempted_at: datetime | None = None
+    profile_snapshot: Profile | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class GeneratedDigest:
+    task_id: str
+    html: str
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    source_date: date
+    status: str
+    total_profiles: int
+    sent_count: int
+    failed_count: int
+    skipped_count: int
+
+
+class OrchestrationRepository(Protocol):
+    async def claim_run(self, source_date: date, *, retry_failed: bool) -> bool: ...
+
+    async def list_eligible_profiles(self) -> list[Profile]: ...
+
+    async def get_or_create_delivery(
+        self, source_date: date, profile: Profile
+    ) -> DeliveryRecord: ...
+
+    async def mark_delivery_generating(
+        self, source_date: date, user_id: str, task_id: str
+    ) -> None: ...
+
+    async def mark_delivery_generated(
+        self, source_date: date, user_id: str, task_id: str
+    ) -> None: ...
+
+    async def mark_delivery_sending(
+        self, source_date: date, user_id: str
+    ) -> None: ...
+
+    async def mark_delivery_sent(
+        self, source_date: date, user_id: str, email_id: str
+    ) -> None: ...
+
+    async def mark_delivery_ambiguous(
+        self, source_date: date, user_id: str, error: str
+    ) -> None: ...
+
+    async def mark_delivery_failed(
+        self, source_date: date, user_id: str, error: str
+    ) -> None: ...
+
+    async def start_profile(
+        self, source_date: date, profile_id: str, task_id: str
+    ) -> None: ...
+
+    async def complete_profile(
+        self, source_date: date, profile_id: str, task_id: str, html: str
+    ) -> None: ...
+
+    async def heartbeat_run(self, source_date: date) -> None: ...
+
+    async def finish_run(self, summary: RunSummary) -> None: ...
+
+    async def fail_run(self, source_date: date, error: str) -> None: ...
+
+
+class SourceFetcher(Protocol):
+    async def fetch(self, source_date: date) -> dict[str, int]: ...
+
+
+class DigestGenerator(Protocol):
+    async def prepare(
+        self, profile: Profile, source_date: date, task_id: str
+    ) -> None: ...
+
+    async def generate(
+        self, profile: Profile, source_date: date, task_id: str
+    ) -> GeneratedDigest: ...
+
+    async def recover(self, task_id: str) -> GeneratedDigest | None: ...
+
+
+class DigestEmailSender(Protocol):
+    async def send_digest(
+        self, *, profile: Profile, source_date: date, task_id: str, html: str
+    ) -> str: ...
+
+
+class DailyDigestOrchestrator:
+    """Run one idempotent source-date batch and isolate per-profile failures."""
+
+    def __init__(
+        self,
+        *,
+        repository: OrchestrationRepository,
+        source_fetcher: SourceFetcher,
+        digest_generator: DigestGenerator,
+        email_sender: DigestEmailSender,
+        profile_start_interval_seconds: float = 60,
+        task_id_factory: Callable[[], str] = lambda: str(uuid.uuid4()),
+        now: Callable[[], datetime] = lambda: datetime.now(timezone.utc),
+        email_idempotency_window: timedelta = timedelta(hours=23),
+        max_concurrent_profiles: int = 2,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._repository = repository
+        self._source_fetcher = source_fetcher
+        self._digest_generator = digest_generator
+        self._email_sender = email_sender
+        self._profile_start_interval_seconds = profile_start_interval_seconds
+        self._task_id_factory = task_id_factory
+        if max_concurrent_profiles < 1:
+            raise ValueError("max_concurrent_profiles must be at least one")
+        self._now = now
+        self._email_idempotency_window = email_idempotency_window
+        self._max_concurrent_profiles = max_concurrent_profiles
+        self._sleep = sleep
+
+    async def run(
+        self, source_date: date, *, retry_failed: bool = False
+    ) -> RunSummary:
+        if not await self._repository.claim_run(
+            source_date, retry_failed=retry_failed
+        ):
+            return RunSummary(source_date, "already_claimed", 0, 0, 0, 0)
+
+        try:
+            source_counts = await self._source_fetcher.fetch(source_date)
+            if sum(source_counts.values()) <= 0:
+                raise RuntimeError(f"No sources available for {source_date.isoformat()}")
+
+            profiles = await self._repository.list_eligible_profiles()
+            semaphore = asyncio.Semaphore(self._max_concurrent_profiles)
+            profile_tasks = []
+            try:
+                for index, profile in enumerate(profiles):
+                    profile_tasks.append(
+                        asyncio.create_task(
+                            self._process_profile(source_date, profile, semaphore),
+                            name=(
+                                f"digest-{source_date.isoformat()}-"
+                                f"{profile.user_id}"
+                            ),
+                        )
+                    )
+                    await self._repository.heartbeat_run(source_date)
+                    if (
+                        index < len(profiles) - 1
+                        and self._profile_start_interval_seconds > 0
+                    ):
+                        await self._sleep(
+                            self._profile_start_interval_seconds
+                        )
+
+                outcomes = (
+                    await asyncio.gather(*profile_tasks)
+                    if profile_tasks
+                    else []
+                )
+            except BaseException:
+                for task in profile_tasks:
+                    task.cancel()
+                if profile_tasks:
+                    await asyncio.gather(*profile_tasks, return_exceptions=True)
+                raise
+            sent_count = outcomes.count("sent")
+            failed_count = outcomes.count("failed")
+            skipped_count = outcomes.count("skipped")
+            status = "completed" if failed_count == 0 else "completed_with_errors"
+            summary = RunSummary(
+                source_date=source_date,
+                status=status,
+                total_profiles=len(profiles),
+                sent_count=sent_count,
+                failed_count=failed_count,
+                skipped_count=skipped_count,
+            )
+            await self._repository.finish_run(summary)
+            return summary
+        except Exception as exc:
+            await self._repository.fail_run(source_date, str(exc))
+            raise
+
+    async def _process_profile(
+        self,
+        source_date: date,
+        profile: Profile,
+        semaphore: asyncio.Semaphore,
+    ) -> str:
+        async with semaphore:
+            try:
+                delivery = await self._repository.get_or_create_delivery(
+                    source_date, profile
+                )
+                delivery_profile = delivery.profile_snapshot or profile
+                if delivery.status is DeliveryStatus.SENT:
+                    return "skipped"
+                if (
+                    delivery.status
+                    in (DeliveryStatus.SENDING, DeliveryStatus.AMBIGUOUS)
+                    and delivery.email_attempted_at is not None
+                    and self._now() - delivery.email_attempted_at
+                    >= self._email_idempotency_window
+                ):
+                    # Resend's key expires after 24 hours. An older unknown
+                    # receipt requires operator reconciliation rather than a
+                    # potentially duplicated customer email.
+                    return "failed"
+
+                digest = None
+                if delivery.task_id:
+                    digest = await self._digest_generator.recover(delivery.task_id)
+
+                if digest is None:
+                    task_id = self._task_id_factory()
+                    await self._repository.mark_delivery_generating(
+                        source_date, profile.user_id, task_id
+                    )
+                    await self._digest_generator.prepare(
+                        delivery_profile, source_date, task_id
+                    )
+                    await self._repository.start_profile(
+                        source_date, delivery_profile.id, task_id
+                    )
+                    digest = await self._digest_generator.generate(
+                        delivery_profile, source_date, task_id
+                    )
+
+                await self._repository.mark_delivery_generated(
+                    source_date, profile.user_id, digest.task_id
+                )
+                await self._repository.complete_profile(
+                    source_date,
+                    delivery_profile.id,
+                    digest.task_id,
+                    digest.html,
+                )
+                # Renew and validate the fenced run claim immediately before
+                # the only irreversible side effect.
+                await self._repository.heartbeat_run(source_date)
+                await self._repository.mark_delivery_sending(
+                    source_date, profile.user_id
+                )
+                email_id = await self._email_sender.send_digest(
+                    profile=delivery_profile,
+                    source_date=source_date,
+                    task_id=digest.task_id,
+                    html=digest.html,
+                )
+                try:
+                    await self._repository.mark_delivery_sent(
+                        source_date, profile.user_id, email_id
+                    )
+                except Exception as exc:
+                    # Resend returned a provider receipt, so never downgrade
+                    # this to FAILED. Preserve ambiguity if the sent checkpoint
+                    # could not be committed; a later operator can reconcile it.
+                    logger.exception(
+                        "Email accepted but sent checkpoint failed",
+                        extra={
+                            "source_date": source_date.isoformat(),
+                            "user_id": profile.user_id,
+                        },
+                    )
+                    try:
+                        await self._repository.mark_delivery_ambiguous(
+                            source_date, profile.user_id, str(exc)
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Could not persist ambiguous email state",
+                            extra={
+                                "source_date": source_date.isoformat(),
+                                "user_id": profile.user_id,
+                            },
+                        )
+                    return "failed"
+                return "sent"
+            except AmbiguousEmailDelivery as exc:
+                await self._repository.mark_delivery_ambiguous(
+                    source_date, profile.user_id, str(exc)
+                )
+                return "failed"
+            except Exception as exc:
+                logger.exception(
+                    "Daily digest delivery failed",
+                    extra={
+                        "source_date": source_date.isoformat(),
+                        "user_id": profile.user_id,
+                    },
+                )
+                await self._repository.mark_delivery_failed(
+                    source_date, profile.user_id, str(exc)
+                )
+                return "failed"
+            finally:
+                await self._repository.heartbeat_run(source_date)

--- a/src/orchestration_adapters.py
+++ b/src/orchestration_adapters.py
@@ -1,0 +1,125 @@
+"""Adapters connecting orchestration to Paperboy's existing backend services."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import date
+from typing import Any
+
+from .models import DigestStatus, TaskStatus
+from .orchestration import GeneratedDigest, Profile
+
+
+class BackendSourceFetcher:
+    """Fetch daily sources through the existing service without self-HTTP."""
+
+    def __init__(self, *, state_manager: Any, fetch_service: Any, timeout_seconds: int):
+        self._state_manager = state_manager
+        self._fetch_service = fetch_service
+        self._timeout_seconds = timeout_seconds
+
+    async def fetch(self, source_date: date) -> dict[str, int]:
+        task_id = str(uuid.uuid4())
+        source_date_text = source_date.isoformat()
+        await self._state_manager.create_fetch_task(
+            task_id, source_date_text, callback_url=None
+        )
+        try:
+            async with asyncio.timeout(self._timeout_seconds):
+                result = await self._fetch_service.fetch_and_store_sources(
+                    source_date_text, task_id, callback_url=None
+                )
+        except Exception as exc:
+            await self._state_manager.update_fetch_task(
+                task_id, "failed", error=str(exc)
+            )
+            raise
+
+        counts = {
+            "arxiv_count": int(result.get("arxiv_count", 0)),
+            "news_count": int(result.get("news_count", 0)),
+        }
+        # The existing-source fast path returns before FetchSourcesService
+        # updates its task record, so make completion explicit and idempotent.
+        await self._state_manager.update_fetch_task(
+            task_id, "completed", result=counts
+        )
+        return counts
+
+
+class BackendDigestGenerator:
+    """Create and run a user-linked digest through the existing service."""
+
+    def __init__(
+        self, *, state_manager: Any, digest_service: Any, timeout_seconds: int
+    ) -> None:
+        self._state_manager = state_manager
+        self._digest_service = digest_service
+        self._timeout_seconds = timeout_seconds
+
+    @staticmethod
+    def _user_info(profile: Profile) -> dict[str, Any]:
+        return {
+            "name": profile.name or "Reader",
+            "title": profile.title,
+            "goals": profile.goals,
+            "news_interest": profile.interests,
+            "research_interests": [profile.goals],
+            "categories": ["cs.AI", "cs.LG"],
+            "affiliation": profile.title,
+            "recent_focus": profile.goals,
+        }
+
+    async def prepare(
+        self, profile: Profile, source_date: date, task_id: str
+    ) -> None:
+        await self._state_manager.create_task_with_source_date(
+            task_id,
+            DigestStatus(status=TaskStatus.PENDING, message="Task created"),
+            user_info=self._user_info(profile),
+            source_date=source_date.isoformat(),
+            digest_type="mixed",
+            callback_url=None,
+            user_id=profile.user_id,
+        )
+
+    async def generate(
+        self, profile: Profile, source_date: date, task_id: str
+    ) -> GeneratedDigest:
+        user_info = self._user_info(profile)
+        source_date_text = source_date.isoformat()
+        try:
+            async with asyncio.timeout(self._timeout_seconds):
+                await self._digest_service.generate_digest(
+                    task_id,
+                    user_info,
+                    callback_url=None,
+                    top_n_articles=5,
+                    top_n_news=5,
+                    source_date=source_date_text,
+                )
+        except Exception as exc:
+            await self._state_manager.update_task(
+                task_id,
+                DigestStatus(status=TaskStatus.FAILED, message=str(exc)),
+            )
+            raise
+
+        result = await self.recover(task_id)
+        if result is None:
+            status = await self._state_manager.get_task(task_id)
+            message = status.message if status else "Digest task disappeared"
+            raise RuntimeError(f"Digest task {task_id} did not complete: {message}")
+        return result
+
+    async def recover(self, task_id: str) -> GeneratedDigest | None:
+        status = await self._state_manager.get_task(task_id)
+        if (
+            status is None
+            or status.status is not TaskStatus.COMPLETED
+            or not status.result
+            or "<html" not in status.result[:1000].lower()
+        ):
+            return None
+        return GeneratedDigest(task_id=task_id, html=status.result)

--- a/src/orchestration_repository.py
+++ b/src/orchestration_repository.py
@@ -1,0 +1,320 @@
+"""Supabase persistence for durable daily digest orchestration."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from supabase import Client
+
+from .orchestration import DeliveryRecord, DeliveryStatus, Profile, RunSummary
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class SupabaseOrchestrationRepository:
+    """Persist run claims and per-user delivery checkpoints in Supabase."""
+
+    def __init__(
+        self,
+        client: Client,
+        *,
+        stale_after_minutes: int = 120,
+    ) -> None:
+        self._client = client
+        self._stale_after = timedelta(minutes=stale_after_minutes)
+        self._run_ids: dict[date, str] = {}
+
+    async def claim_run(self, source_date: date, *, retry_failed: bool) -> bool:
+        run_id = str(uuid.uuid4())
+        stale_before = (_utc_now() - self._stale_after).isoformat()
+        response = self._client.rpc(
+            "claim_orchestration_run",
+            {
+                "p_source_date": source_date.isoformat(),
+                "p_run_id": run_id,
+                "p_stale_before": stale_before,
+                "p_retry_failed": retry_failed,
+            },
+        ).execute()
+        claimed = response.data is True or response.data == [True]
+        if claimed:
+            self._run_ids[source_date] = run_id
+        return claimed
+
+    async def list_eligible_profiles(self) -> list[Profile]:
+        response = (
+            self._client.table("profiles")
+            .select("id,user_id,email,name,title,goals,interests")
+            .not_.is_("goals", "null")
+            .is_("remove", "null")
+            .execute()
+        )
+        profiles = []
+        for row in response.data or []:
+            goals = row.get("goals")
+            if not goals:
+                continue
+            profiles.append(
+                Profile(
+                    id=str(row["id"]),
+                    user_id=str(row["user_id"]),
+                    email=row.get("email"),
+                    name=row.get("name"),
+                    title=row.get("title"),
+                    goals=str(goals),
+                    interests=row.get("interests"),
+                )
+            )
+        return profiles
+
+    async def get_or_create_delivery(
+        self, source_date: date, profile: Profile
+    ) -> DeliveryRecord:
+        run_id = self._active_run_id(source_date)
+        response = self._client.rpc(
+            "claim_orchestration_delivery",
+            {
+                "p_source_date": source_date.isoformat(),
+                "p_run_id": run_id,
+                "p_profile_id": profile.id,
+                "p_user_id": profile.user_id,
+                "p_profile_snapshot": {
+                    "id": profile.id,
+                    "user_id": profile.user_id,
+                    "email": profile.email,
+                    "name": profile.name,
+                    "title": profile.title,
+                    "goals": profile.goals,
+                    "interests": profile.interests,
+                },
+            },
+        ).execute()
+        if not response.data:
+            raise RuntimeError("Daily orchestration run claim was lost")
+        return self._delivery_from_row(source_date, response.data[0])
+
+    async def mark_delivery_generating(
+        self, source_date: date, user_id: str, task_id: str
+    ) -> None:
+        self._update_delivery(
+            source_date,
+            user_id,
+            {
+                "status": DeliveryStatus.GENERATING.value,
+                "task_id": task_id,
+                "last_error": None,
+            },
+        )
+
+    async def mark_delivery_generated(
+        self, source_date: date, user_id: str, task_id: str
+    ) -> None:
+        self._update_delivery(
+            source_date,
+            user_id,
+            {
+                "status": DeliveryStatus.GENERATED.value,
+                "task_id": task_id,
+                "last_error": None,
+            },
+        )
+
+    async def mark_delivery_sending(
+        self, source_date: date, user_id: str
+    ) -> None:
+        self._update_delivery(
+            source_date,
+            user_id,
+            {
+                "status": DeliveryStatus.SENDING.value,
+                "email_attempted_at": _utc_now().isoformat(),
+                "last_error": None,
+            },
+        )
+
+    async def mark_delivery_sent(
+        self, source_date: date, user_id: str, email_id: str
+    ) -> None:
+        now = _utc_now().isoformat()
+        self._update_delivery(
+            source_date,
+            user_id,
+            {
+                "status": DeliveryStatus.SENT.value,
+                "email_id": email_id,
+                "email_sent_at": now,
+                "last_error": None,
+            },
+        )
+
+    async def mark_delivery_ambiguous(
+        self, source_date: date, user_id: str, error: str
+    ) -> None:
+        self._update_delivery(
+            source_date,
+            user_id,
+            {
+                "status": DeliveryStatus.AMBIGUOUS.value,
+                "last_error": error[:2000],
+            },
+        )
+
+    async def mark_delivery_failed(
+        self, source_date: date, user_id: str, error: str
+    ) -> None:
+        self._update_delivery(
+            source_date,
+            user_id,
+            {
+                "status": DeliveryStatus.FAILED.value,
+                "last_error": error[:2000],
+            },
+        )
+
+    async def start_profile(
+        self, source_date: date, profile_id: str, task_id: str
+    ) -> None:
+        self._update_profile_with_claim(
+            source_date=source_date,
+            profile_id=profile_id,
+            task_id=task_id,
+            html=None,
+        )
+
+    async def complete_profile(
+        self, source_date: date, profile_id: str, task_id: str, html: str
+    ) -> None:
+        self._update_profile_with_claim(
+            source_date=source_date,
+            profile_id=profile_id,
+            task_id=task_id,
+            html=html,
+        )
+
+    async def heartbeat_run(self, source_date: date) -> None:
+        self._update_active_run(
+            source_date, {"heartbeat_at": _utc_now().isoformat()}
+        )
+
+    async def finish_run(self, summary: RunSummary) -> None:
+        now = _utc_now().isoformat()
+        self._update_active_run(
+            summary.source_date,
+            {
+                "status": summary.status,
+                "total_profiles": summary.total_profiles,
+                "sent_count": summary.sent_count,
+                "failed_count": summary.failed_count,
+                "skipped_count": summary.skipped_count,
+                "heartbeat_at": now,
+                "completed_at": now,
+                "last_error": None,
+            },
+        )
+
+    async def fail_run(self, source_date: date, error: str) -> None:
+        now = _utc_now().isoformat()
+        self._update_active_run(
+            source_date,
+            {
+                "status": "failed",
+                "heartbeat_at": now,
+                "completed_at": now,
+                "last_error": error[:2000],
+            },
+        )
+
+    async def get_run(self, source_date: date) -> dict[str, Any] | None:
+        response = (
+            self._client.table("orchestration_runs")
+            .select("*")
+            .eq("source_date", source_date.isoformat())
+            .limit(1)
+            .execute()
+        )
+        return response.data[0] if response.data else None
+
+    @staticmethod
+    def _delivery_from_row(
+        source_date: date, row: dict[str, Any]
+    ) -> DeliveryRecord:
+        snapshot = row.get("profile_snapshot")
+        return DeliveryRecord(
+            source_date=source_date,
+            profile_id=str(row["profile_id"]),
+            user_id=str(row["user_id"]),
+            status=DeliveryStatus(row["status"]),
+            task_id=row.get("task_id"),
+            email_id=row.get("email_id"),
+            email_attempted_at=(
+                datetime.fromisoformat(
+                    row["email_attempted_at"].replace("Z", "+00:00")
+                )
+                if row.get("email_attempted_at")
+                else None
+            ),
+            profile_snapshot=(Profile(**snapshot) if snapshot else None),
+            error=row.get("last_error"),
+        )
+
+    def _update_delivery(
+        self, source_date: date, user_id: str, fields: dict[str, Any]
+    ) -> None:
+        payload = {**fields, "updated_at": _utc_now().isoformat()}
+        response = (
+            self._client.table("orchestration_deliveries")
+            .update(payload)
+            .eq("source_date", source_date.isoformat())
+            .eq("user_id", user_id)
+            .eq("run_id", self._active_run_id(source_date))
+            .execute()
+        )
+        if response.data == []:
+            raise RuntimeError("Daily orchestration delivery claim was lost")
+
+    def _update_profile_with_claim(
+        self,
+        *,
+        source_date: date,
+        profile_id: str,
+        task_id: str,
+        html: str | None,
+    ) -> None:
+        run_id = self._active_run_id(source_date)
+        response = self._client.rpc(
+            "update_orchestration_profile",
+            {
+                "p_source_date": source_date.isoformat(),
+                "p_run_id": run_id,
+                "p_profile_id": profile_id,
+                "p_task_id": task_id,
+                "p_html": html,
+            },
+        ).execute()
+        updated = response.data is True or response.data == [True]
+        if not updated:
+            raise RuntimeError("Daily orchestration run claim was lost")
+
+    def _active_run_id(self, source_date: date) -> str:
+        run_id = self._run_ids.get(source_date)
+        if not run_id:
+            raise RuntimeError(f"No active claim for {source_date.isoformat()}")
+        return run_id
+
+    def _update_active_run(
+        self, source_date: date, fields: dict[str, Any]
+    ) -> None:
+        run_id = self._active_run_id(source_date)
+        response = (
+            self._client.table("orchestration_runs")
+            .update(fields)
+            .eq("source_date", source_date.isoformat())
+            .eq("run_id", run_id)
+            .execute()
+        )
+        if response.data == []:
+            raise RuntimeError("Daily orchestration run claim was lost")

--- a/src/orchestration_scheduler.py
+++ b/src/orchestration_scheduler.py
@@ -1,0 +1,65 @@
+"""Small UTC scheduler for the always-on Fly.io application process."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class DailyOrchestrationScheduler:
+    """Check for the daily due date; database claiming supplies uniqueness."""
+
+    def __init__(
+        self,
+        orchestrator: Any,
+        *,
+        hour_utc: int = 13,
+        poll_seconds: float = 60,
+        catchup_hours: float = 24,
+    ) -> None:
+        if not 0 <= hour_utc <= 23:
+            raise ValueError("hour_utc must be between 0 and 23")
+        self._orchestrator = orchestrator
+        if catchup_hours <= 0:
+            raise ValueError("catchup_hours must be positive")
+        self._hour_utc = hour_utc
+        self._poll_seconds = poll_seconds
+        self._catchup_window = timedelta(hours=catchup_hours)
+        self._stop = asyncio.Event()
+
+    async def tick(self, now: datetime | None = None) -> Any | None:
+        current = now or datetime.now(timezone.utc)
+        if current.tzinfo is None:
+            raise ValueError("Scheduler requires a timezone-aware datetime")
+        current = current.astimezone(timezone.utc)
+        scheduled_today = current.replace(
+            hour=self._hour_utc, minute=0, second=0, microsecond=0
+        )
+        latest_slot = scheduled_today
+        if current < scheduled_today:
+            latest_slot -= timedelta(days=1)
+        if current - latest_slot > self._catchup_window:
+            return None
+        source_date = (latest_slot - timedelta(days=1)).date()
+        return await self._orchestrator.run(source_date, retry_failed=False)
+
+    async def run_forever(self) -> None:
+        while not self._stop.is_set():
+            try:
+                await self.tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Daily orchestration scheduler tick failed")
+
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._poll_seconds)
+            except asyncio.TimeoutError:
+                pass
+
+    def stop(self) -> None:
+        self._stop.set()

--- a/src/resend_email.py
+++ b/src/resend_email.py
@@ -1,0 +1,107 @@
+"""Resend adapter for idempotent digest email delivery."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+from typing import Awaitable, Callable
+
+import httpx
+
+from .orchestration import AmbiguousEmailDelivery, Profile
+
+
+class ResendEmailSender:
+    """Send digest HTML through Resend without duplicating retry attempts."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        from_address: str,
+        client: httpx.AsyncClient | None = None,
+        max_attempts: int = 3,
+        retry_delay_seconds: float = 5,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        if not api_key:
+            raise ValueError("Resend API key is required")
+        self._api_key = api_key
+        self._from_address = from_address
+        self._client = client or httpx.AsyncClient(timeout=30)
+        self._owns_client = client is None
+        self._max_attempts = max_attempts
+        self._retry_delay_seconds = retry_delay_seconds
+        self._sleep = sleep
+
+    async def send_digest(
+        self,
+        *,
+        profile: Profile,
+        source_date: date,
+        task_id: str,
+        html: str,
+    ) -> str:
+        if not profile.email:
+            raise ValueError("Profile has no delivery email")
+
+        subject = (
+            f"Paperboy | {profile.name}'s Daily Digest"
+            if profile.name
+            else "Paperboy | Your Daily Digest"
+        )
+        payload = {
+            "from": self._from_address,
+            "to": [profile.email],
+            "html": html,
+            "subject": subject,
+            "tags": [{"name": "task_id", "value": task_id}],
+        }
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Idempotency-Key": (
+                f"paperboy:{source_date.isoformat()}:{profile.user_id}"
+            ),
+        }
+
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                response = await self._client.post(
+                    "https://api.resend.com/emails",
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                email_id = response.json().get("id")
+                if not email_id:
+                    raise AmbiguousEmailDelivery(
+                        "Resend accepted the request without returning an email id"
+                    )
+                return str(email_id)
+            except httpx.TransportError as exc:
+                if attempt >= self._max_attempts:
+                    raise AmbiguousEmailDelivery(
+                        "Resend delivery receipt was not observed"
+                    ) from exc
+            except AmbiguousEmailDelivery:
+                if attempt >= self._max_attempts:
+                    raise
+            except httpx.HTTPStatusError as exc:
+                status = exc.response.status_code
+                retryable = status == 429 or status >= 500
+                if not retryable:
+                    raise
+                if attempt >= self._max_attempts:
+                    raise AmbiguousEmailDelivery(
+                        f"Resend returned repeated retryable status {status}"
+                    ) from exc
+
+            await self._sleep(self._retry_delay_seconds)
+
+        raise AmbiguousEmailDelivery(
+            "Resend delivery exhausted without a receipt"
+        )
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()

--- a/src/state_supabase.py
+++ b/src/state_supabase.py
@@ -13,13 +13,13 @@ from .models import DigestStatus, TaskStatus, ArticleAnalysis
 class TaskStateManager:
     """Task state manager using Supabase for persistence."""
     
-    def __init__(self):
+    def __init__(self, client: Client = None):
         self.supabase_url = os.getenv('SUPABASE_URL')
         self.supabase_key = os.getenv('SUPABASE_KEY')
-        if not self.supabase_url or not self.supabase_key:
+        if client is None and (not self.supabase_url or not self.supabase_key):
             raise ValueError("SUPABASE_URL and SUPABASE_KEY must be set")
-        
-        self.client = create_client(self.supabase_url, self.supabase_key)
+
+        self.client = client or create_client(self.supabase_url, self.supabase_key)
         self.table = 'digest_tasks'
         
         logfire.info("TaskStateManager initialized with Supabase")
@@ -174,8 +174,17 @@ class TaskStateManager:
         self.client.table(self.table).update(data).eq('task_id', task_id).execute()
         logfire.info(f"Task {task_id} updated to status {status.status.value} with source_date {source_date}")
     
-    async def create_task_with_source_date(self, task_id: str, status: DigestStatus, user_info: Dict[str, Any] = None, source_date: str = None, digest_type: str = None, callback_url: str = None) -> None:
-        """Create a new task with source_date and digest_type fields."""
+    async def create_task_with_source_date(
+        self,
+        task_id: str,
+        status: DigestStatus,
+        user_info: Dict[str, Any] = None,
+        source_date: str = None,
+        digest_type: str = None,
+        callback_url: str = None,
+        user_id: str = None,
+    ) -> None:
+        """Create a task with source metadata and an optional owning user."""
         data = {
             'task_id': task_id,
             'status': status.status.value,
@@ -194,6 +203,9 @@ class TaskStateManager:
 
         if callback_url:
             data['callback_url'] = callback_url
+
+        if user_id:
+            data['user_id'] = user_id
 
         self.client.table(self.table).insert(data).execute()
         logfire.info(f"Task {task_id} created with source_date {source_date} and digest_type {digest_type}")

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,14 @@
+"""Shutdown behavior needed by Uvicorn-hosted background orchestration."""
+
+import asyncio
+
+from src.graceful_shutdown import GracefulShutdown
+
+
+def test_lifespan_can_initiate_shutdown_without_replacing_uvicorn_signals() -> None:
+    handler = GracefulShutdown(timeout=1)
+
+    handler.initiate_shutdown()
+    asyncio.run(handler.wait_for_shutdown())
+
+    assert handler.is_shutting_down()

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,0 +1,459 @@
+"""Behavioral tests for backend-hosted daily digest orchestration."""
+
+import asyncio
+from dataclasses import replace
+from datetime import date, datetime, timedelta, timezone
+
+from src.orchestration import (
+    DailyDigestOrchestrator,
+    DeliveryRecord,
+    DeliveryStatus,
+    GeneratedDigest,
+    Profile,
+)
+
+
+class RecordingRepository:
+    def __init__(self, profiles: list[Profile]) -> None:
+        self.profiles = profiles
+        self.claimed = True
+        self.deliveries: dict[str, DeliveryRecord] = {}
+        self.started_profiles: list[tuple[str, str]] = []
+        self.completed_profiles: list[tuple[str, str, str]] = []
+        self.finished_runs = []
+
+    async def claim_run(self, source_date: date, *, retry_failed: bool) -> bool:
+        return self.claimed
+
+    async def list_eligible_profiles(self) -> list[Profile]:
+        return self.profiles
+
+    async def get_or_create_delivery(
+        self, source_date: date, profile: Profile
+    ) -> DeliveryRecord:
+        return self.deliveries.setdefault(
+            profile.user_id,
+            DeliveryRecord(
+                source_date=source_date,
+                profile_id=profile.id,
+                user_id=profile.user_id,
+                status=DeliveryStatus.PENDING,
+            ),
+        )
+
+    async def mark_delivery_generating(
+        self, source_date: date, user_id: str, task_id: str
+    ) -> None:
+        self.deliveries[user_id] = replace(
+            self.deliveries[user_id],
+            status=DeliveryStatus.GENERATING,
+            task_id=task_id,
+        )
+
+    async def mark_delivery_generated(
+        self, source_date: date, user_id: str, task_id: str
+    ) -> None:
+        self.deliveries[user_id] = replace(
+            self.deliveries[user_id],
+            status=DeliveryStatus.GENERATED,
+            task_id=task_id,
+        )
+
+    async def mark_delivery_sending(
+        self, source_date: date, user_id: str
+    ) -> None:
+        self.deliveries[user_id] = replace(
+            self.deliveries[user_id],
+            status=DeliveryStatus.SENDING,
+        )
+
+    async def mark_delivery_sent(
+        self, source_date: date, user_id: str, email_id: str
+    ) -> None:
+        self.deliveries[user_id] = replace(
+            self.deliveries[user_id],
+            status=DeliveryStatus.SENT,
+            email_id=email_id,
+        )
+
+    async def mark_delivery_ambiguous(
+        self, source_date: date, user_id: str, error: str
+    ) -> None:
+        self.deliveries[user_id] = replace(
+            self.deliveries[user_id],
+            status=DeliveryStatus.AMBIGUOUS,
+            error=error,
+        )
+
+    async def mark_delivery_failed(
+        self, source_date: date, user_id: str, error: str
+    ) -> None:
+        self.deliveries[user_id] = replace(
+            self.deliveries[user_id],
+            status=DeliveryStatus.FAILED,
+            error=error,
+        )
+
+    async def start_profile(
+        self, source_date: date, profile_id: str, task_id: str
+    ) -> None:
+        self.started_profiles.append((profile_id, task_id))
+
+    async def complete_profile(
+        self, source_date: date, profile_id: str, task_id: str, html: str
+    ) -> None:
+        self.completed_profiles.append((profile_id, task_id, html))
+
+    async def heartbeat_run(self, source_date: date) -> None:
+        pass
+
+    async def finish_run(self, summary) -> None:
+        self.finished_runs.append(summary)
+
+    async def fail_run(self, source_date: date, error: str) -> None:
+        raise AssertionError(f"run unexpectedly failed: {error}")
+
+
+class RecordingSourceFetcher:
+    def __init__(self) -> None:
+        self.dates: list[date] = []
+
+    async def fetch(self, source_date: date) -> dict[str, int]:
+        self.dates.append(source_date)
+        return {"arxiv_count": 10, "news_count": 5}
+
+
+class RecordingDigestGenerator:
+    def __init__(self) -> None:
+        self.prepared: list[tuple[Profile, date, str]] = []
+        self.calls: list[tuple[Profile, date, str]] = []
+
+    async def prepare(
+        self, profile: Profile, source_date: date, task_id: str
+    ) -> None:
+        self.prepared.append((profile, source_date, task_id))
+
+    async def generate(
+        self, profile: Profile, source_date: date, task_id: str
+    ) -> GeneratedDigest:
+        self.calls.append((profile, source_date, task_id))
+        return GeneratedDigest(task_id=task_id, html="<html>digest</html>")
+
+    async def recover(self, task_id: str) -> GeneratedDigest | None:
+        return None
+
+
+class RecordingEmailSender:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def send_digest(
+        self, *, profile: Profile, source_date: date, task_id: str, html: str
+    ) -> str:
+        self.calls.append((profile, source_date, task_id, html))
+        return "email-1"
+
+
+def test_daily_run_fetches_generates_links_and_emails_each_profile() -> None:
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Reader",
+        title="Researcher",
+        goals="Track AI research",
+        interests="AI policy",
+    )
+    repository = RecordingRepository([profile])
+    fetcher = RecordingSourceFetcher()
+    generator = RecordingDigestGenerator()
+    email_sender = RecordingEmailSender()
+    orchestrator = DailyDigestOrchestrator(
+        repository=repository,
+        source_fetcher=fetcher,
+        digest_generator=generator,
+        email_sender=email_sender,
+        profile_start_interval_seconds=0,
+        task_id_factory=lambda: "task-1",
+    )
+
+    summary = asyncio.run(orchestrator.run(date(2026, 7, 9)))
+
+    assert summary.status == "completed"
+    assert summary.total_profiles == 1
+    assert summary.sent_count == 1
+    assert summary.failed_count == 0
+    assert fetcher.dates == [date(2026, 7, 9)]
+    assert generator.prepared == [(profile, date(2026, 7, 9), "task-1")]
+    assert generator.calls == [(profile, date(2026, 7, 9), "task-1")]
+    assert repository.started_profiles == [("profile-1", "task-1")]
+    assert repository.completed_profiles == [
+        ("profile-1", "task-1", "<html>digest</html>")
+    ]
+    assert email_sender.calls == [
+        (profile, date(2026, 7, 9), "task-1", "<html>digest</html>")
+    ]
+    assert repository.deliveries["user-1"].status is DeliveryStatus.SENT
+
+
+def test_profiles_launch_at_configured_cadence_with_bounded_overlap() -> None:
+    first = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="one@example.com",
+        name="One",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+    second = replace(
+        first,
+        id="profile-2",
+        user_id="user-2",
+        email="two@example.com",
+        name="Two",
+    )
+    repository = RecordingRepository([first, second])
+    started_two = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    class OverlapGenerator(RecordingDigestGenerator):
+        async def generate(
+            self, profile: Profile, source_date: date, task_id: str
+        ) -> GeneratedDigest:
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            if profile.user_id == "user-1":
+                await started_two.wait()
+            else:
+                started_two.set()
+            result = await super().generate(profile, source_date, task_id)
+            active -= 1
+            return result
+
+    sleeps = []
+
+    async def release_cadence(seconds: float) -> None:
+        sleeps.append(seconds)
+        await asyncio.sleep(0)
+
+    task_ids = iter(["task-1", "task-2"])
+    orchestrator = DailyDigestOrchestrator(
+        repository=repository,
+        source_fetcher=RecordingSourceFetcher(),
+        digest_generator=OverlapGenerator(),
+        email_sender=RecordingEmailSender(),
+        profile_start_interval_seconds=60,
+        max_concurrent_profiles=2,
+        sleep=release_cadence,
+        task_id_factory=lambda: next(task_ids),
+    )
+
+    summary = asyncio.run(orchestrator.run(date(2026, 7, 9)))
+
+    assert summary.sent_count == 2
+    assert sleeps == [60]
+    assert max_active == 2
+
+
+def test_profile_failure_is_recorded_without_blocking_later_profiles() -> None:
+    first = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="one@example.com",
+        name="One",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+    second = replace(
+        first,
+        id="profile-2",
+        user_id="user-2",
+        email="two@example.com",
+        name="Two",
+    )
+    repository = RecordingRepository([first, second])
+    fetcher = RecordingSourceFetcher()
+
+    class FailFirstGenerator(RecordingDigestGenerator):
+        async def generate(
+            self, profile: Profile, source_date: date, task_id: str
+        ) -> GeneratedDigest:
+            if profile.user_id == "user-1":
+                raise RuntimeError("provider unavailable")
+            return await super().generate(profile, source_date, task_id)
+
+    generator = FailFirstGenerator()
+    email_sender = RecordingEmailSender()
+    task_ids = iter(["task-1", "task-2"])
+    orchestrator = DailyDigestOrchestrator(
+        repository=repository,
+        source_fetcher=fetcher,
+        digest_generator=generator,
+        email_sender=email_sender,
+        profile_start_interval_seconds=0,
+        task_id_factory=lambda: next(task_ids),
+    )
+
+    summary = asyncio.run(orchestrator.run(date(2026, 7, 9)))
+
+    assert summary.status == "completed_with_errors"
+    assert summary.failed_count == 1
+    assert summary.sent_count == 1
+    assert repository.deliveries["user-1"].status is DeliveryStatus.FAILED
+    assert repository.deliveries["user-1"].task_id == "task-1"
+    assert repository.deliveries["user-2"].status is DeliveryStatus.SENT
+    assert email_sender.calls[0][0].user_id == "user-2"
+
+
+def test_retry_resumes_completed_task_without_regenerating_digest() -> None:
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Reader",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+    repository = RecordingRepository([profile])
+    repository.deliveries[profile.user_id] = DeliveryRecord(
+        source_date=date(2026, 7, 9),
+        profile_id=profile.id,
+        user_id=profile.user_id,
+        status=DeliveryStatus.GENERATED,
+        task_id="existing-task",
+        profile_snapshot=replace(profile, email="original@example.com"),
+    )
+
+    class RecoveringGenerator(RecordingDigestGenerator):
+        async def recover(self, task_id: str) -> GeneratedDigest | None:
+            return GeneratedDigest(task_id=task_id, html="<html>recovered</html>")
+
+    generator = RecoveringGenerator()
+    email_sender = RecordingEmailSender()
+    orchestrator = DailyDigestOrchestrator(
+        repository=repository,
+        source_fetcher=RecordingSourceFetcher(),
+        digest_generator=generator,
+        email_sender=email_sender,
+        profile_start_interval_seconds=0,
+        task_id_factory=lambda: (_ for _ in ()).throw(
+            AssertionError("new task should not be created")
+        ),
+    )
+
+    summary = asyncio.run(
+        orchestrator.run(date(2026, 7, 9), retry_failed=True)
+    )
+
+    assert summary.sent_count == 1
+    assert generator.prepared == []
+    assert generator.calls == []
+    assert repository.started_profiles == []
+    assert repository.completed_profiles == [
+        ("profile-1", "existing-task", "<html>recovered</html>")
+    ]
+    assert email_sender.calls[0][0].email == "original@example.com"
+    assert email_sender.calls[0][2] == "existing-task"
+
+
+def test_email_receipt_checkpoint_failure_never_downgrades_to_resendable_failed() -> None:
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Reader",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+
+    class SentCheckpointFailureRepository(RecordingRepository):
+        async def mark_delivery_sent(
+            self, source_date: date, user_id: str, email_id: str
+        ) -> None:
+            raise RuntimeError("database unavailable after provider receipt")
+
+    repository = SentCheckpointFailureRepository([profile])
+    orchestrator = DailyDigestOrchestrator(
+        repository=repository,
+        source_fetcher=RecordingSourceFetcher(),
+        digest_generator=RecordingDigestGenerator(),
+        email_sender=RecordingEmailSender(),
+        profile_start_interval_seconds=0,
+        task_id_factory=lambda: "task-1",
+    )
+
+    summary = asyncio.run(orchestrator.run(date(2026, 7, 9)))
+
+    assert summary.failed_count == 1
+    assert repository.deliveries[profile.user_id].status is DeliveryStatus.AMBIGUOUS
+    assert "database unavailable" in repository.deliveries[profile.user_id].error
+
+
+def test_ambiguous_email_older_than_provider_window_is_not_resent() -> None:
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Reader",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+    now = datetime(2026, 7, 10, 13, tzinfo=timezone.utc)
+    repository = RecordingRepository([profile])
+    repository.deliveries[profile.user_id] = DeliveryRecord(
+        source_date=date(2026, 7, 9),
+        profile_id=profile.id,
+        user_id=profile.user_id,
+        status=DeliveryStatus.AMBIGUOUS,
+        task_id="existing-task",
+        email_attempted_at=now - timedelta(hours=23),
+    )
+    generator = RecordingDigestGenerator()
+    email_sender = RecordingEmailSender()
+    orchestrator = DailyDigestOrchestrator(
+        repository=repository,
+        source_fetcher=RecordingSourceFetcher(),
+        digest_generator=generator,
+        email_sender=email_sender,
+        profile_start_interval_seconds=0,
+        now=lambda: now,
+    )
+
+    summary = asyncio.run(
+        orchestrator.run(date(2026, 7, 9), retry_failed=True)
+    )
+
+    assert summary.status == "completed_with_errors"
+    assert summary.failed_count == 1
+    assert generator.calls == []
+    assert email_sender.calls == []
+    assert repository.deliveries[profile.user_id].status is DeliveryStatus.AMBIGUOUS
+
+
+def test_already_claimed_run_does_not_repeat_external_work() -> None:
+    repository = RecordingRepository([])
+    repository.claimed = False
+    fetcher = RecordingSourceFetcher()
+    generator = RecordingDigestGenerator()
+    email_sender = RecordingEmailSender()
+    orchestrator = DailyDigestOrchestrator(
+        repository=repository,
+        source_fetcher=fetcher,
+        digest_generator=generator,
+        email_sender=email_sender,
+        profile_start_interval_seconds=0,
+    )
+
+    summary = asyncio.run(orchestrator.run(date(2026, 7, 9)))
+
+    assert summary.status == "already_claimed"
+    assert fetcher.dates == []
+    assert generator.calls == []
+    assert email_sender.calls == []

--- a/tests/test_orchestration_adapters.py
+++ b/tests/test_orchestration_adapters.py
@@ -1,0 +1,142 @@
+"""Integration tests for adapters around the existing digest services."""
+
+import asyncio
+from datetime import date
+
+from src.models import DigestStatus, TaskStatus
+from src.orchestration import Profile
+from src.orchestration_adapters import BackendDigestGenerator, BackendSourceFetcher
+
+
+class RecordingStateManager:
+    def __init__(self) -> None:
+        self.created = []
+        self.status = DigestStatus(
+            status=TaskStatus.COMPLETED,
+            message="done",
+            result="<html>generated</html>",
+        )
+
+    async def create_task_with_source_date(self, *args, **kwargs) -> None:
+        self.created.append((args, kwargs))
+
+    async def get_task(self, task_id: str) -> DigestStatus:
+        return self.status
+
+
+class RecordingFetchStateManager:
+    def __init__(self) -> None:
+        self.created = []
+        self.updated = []
+
+    async def create_fetch_task(self, *args, **kwargs) -> None:
+        self.created.append((args, kwargs))
+
+    async def update_fetch_task(self, *args, **kwargs) -> None:
+        self.updated.append((args, kwargs))
+
+
+class ExistingSourceService:
+    async def fetch_and_store_sources(self, *args, **kwargs):
+        return {
+            "status": "completed",
+            "arxiv_count": 8,
+            "news_count": 3,
+        }
+
+
+def test_backend_source_fetcher_completes_tracking_for_cached_sources() -> None:
+    state_manager = RecordingFetchStateManager()
+    fetcher = BackendSourceFetcher(
+        state_manager=state_manager,
+        fetch_service=ExistingSourceService(),
+        timeout_seconds=30,
+    )
+
+    counts = asyncio.run(fetcher.fetch(date(2026, 7, 9)))
+
+    assert counts == {"arxiv_count": 8, "news_count": 3}
+    task_id = state_manager.created[0][0][0]
+    assert state_manager.updated[-1] == (
+        (task_id, "completed"),
+        {"result": counts},
+    )
+
+
+class RecordingDigestService:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def generate_digest(self, *args, **kwargs) -> None:
+        self.calls.append((args, kwargs))
+
+
+def test_backend_generator_rejects_completed_error_text_as_an_email_digest() -> None:
+    state_manager = RecordingStateManager()
+    state_manager.status = DigestStatus(
+        status=TaskStatus.COMPLETED,
+        message="Digest generated successfully",
+        result="No pre-fetched sources available for date",
+    )
+    generator = BackendDigestGenerator(
+        state_manager=state_manager,
+        digest_service=RecordingDigestService(),
+        timeout_seconds=30,
+    )
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Reader",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+
+    asyncio.run(generator.prepare(profile, date(2026, 7, 9), "task-1"))
+    try:
+        asyncio.run(generator.generate(profile, date(2026, 7, 9), "task-1"))
+    except RuntimeError as exc:
+        assert "did not complete" in str(exc)
+    else:
+        raise AssertionError("plain error text must not be sent as HTML email")
+
+
+def test_backend_generator_creates_user_linked_task_and_calls_service_directly() -> None:
+    state_manager = RecordingStateManager()
+    digest_service = RecordingDigestService()
+    generator = BackendDigestGenerator(
+        state_manager=state_manager,
+        digest_service=digest_service,
+        timeout_seconds=30,
+    )
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Reader",
+        title="Researcher",
+        goals="Track AI",
+        interests="AI policy",
+    )
+
+    asyncio.run(generator.prepare(profile, date(2026, 7, 9), "task-1"))
+    result = asyncio.run(
+        generator.generate(profile, date(2026, 7, 9), "task-1")
+    )
+
+    assert result.task_id == "task-1"
+    assert result.html == "<html>generated</html>"
+    _, create_kwargs = state_manager.created[0]
+    assert create_kwargs["user_id"] == "user-1"
+    assert create_kwargs["source_date"] == "2026-07-09"
+    assert create_kwargs["callback_url"] is None
+    service_args, service_kwargs = digest_service.calls[0]
+    assert service_args[0] == "task-1"
+    assert service_args[1]["news_interest"] == "AI policy"
+    assert service_kwargs == {
+        "callback_url": None,
+        "top_n_articles": 5,
+        "top_n_news": 5,
+        "source_date": "2026-07-09",
+    }

--- a/tests/test_orchestration_api.py
+++ b/tests/test_orchestration_api.py
@@ -1,0 +1,72 @@
+"""Behavioral tests for protected orchestration operations."""
+
+import asyncio
+from datetime import date
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from src import main
+from src.api_models import OrchestrationRunRequest
+
+
+class RecordingOrchestrator:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def run(self, source_date, *, retry_failed):
+        self.calls.append((source_date, retry_failed))
+
+
+async def _request_manual_run():
+    orchestrator = RecordingOrchestrator()
+    main.app.state.orchestrator = orchestrator
+    main.app.state.orchestration_manual_tasks = set()
+    response = await main.run_daily_orchestration(
+        OrchestrationRunRequest(
+            source_date=date(2026, 7, 9), retry_failed=True
+        )
+    )
+    await asyncio.gather(*main.app.state.orchestration_manual_tasks)
+    return response, orchestrator
+
+
+def test_admin_route_requires_api_key_through_the_real_asgi_app() -> None:
+    async def request_without_key():
+        orchestrator = RecordingOrchestrator()
+        main.app.state.orchestrator = orchestrator
+        main.app.state.orchestration_manual_tasks = set()
+        transport = httpx.ASGITransport(app=main.app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/admin/orchestration/run",
+                json={"source_date": "2026-07-09"},
+            )
+        return response, orchestrator
+
+    response, orchestrator = asyncio.run(request_without_key())
+
+    assert response.status_code == 403
+    assert orchestrator.calls == []
+
+
+def test_manual_run_returns_immediately_and_executes_durable_coordinator() -> None:
+    response, orchestrator = asyncio.run(_request_manual_run())
+
+    assert response.status == "accepted"
+    assert response.source_date == date(2026, 7, 9)
+    assert orchestrator.calls == [(date(2026, 7, 9), True)]
+
+
+def test_manual_run_is_unavailable_until_orchestration_is_enabled() -> None:
+    main.app.state.orchestrator = None
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(
+            main.run_daily_orchestration(OrchestrationRunRequest())
+        )
+
+    assert excinfo.value.status_code == 503

--- a/tests/test_orchestration_repository.py
+++ b/tests/test_orchestration_repository.py
@@ -1,0 +1,97 @@
+"""Boundary tests for Supabase orchestration persistence."""
+
+import asyncio
+from datetime import date
+from types import SimpleNamespace
+
+from src.orchestration_repository import SupabaseOrchestrationRepository
+
+
+class Query:
+    def __init__(self, rows):
+        self.rows = rows
+        self.operations = []
+        self.not_ = self
+
+    def select(self, fields):
+        self.operations.append(("select", fields))
+        return self
+
+    def is_(self, field, value):
+        self.operations.append(("is", field, value))
+        return self
+
+    def eq(self, field, value):
+        self.operations.append(("eq", field, value))
+        return self
+
+    def limit(self, value):
+        self.operations.append(("limit", value))
+        return self
+
+    def execute(self):
+        return SimpleNamespace(data=self.rows)
+
+
+class RecordingClient:
+    def __init__(self, *, rpc_result=True, profile_rows=None):
+        self.rpc_result = rpc_result
+        self.profile_query = Query(profile_rows or [])
+        self.rpc_calls = []
+
+    def rpc(self, name, parameters):
+        self.rpc_calls.append((name, parameters))
+        return Query([True] if self.rpc_result else [False])
+
+    def table(self, name):
+        assert name == "profiles"
+        return self.profile_query
+
+
+def test_repository_claim_uses_atomic_rpc_and_records_retry_intent() -> None:
+    client = RecordingClient(rpc_result=True)
+    repository = SupabaseOrchestrationRepository(client, stale_after_minutes=90)
+
+    claimed = asyncio.run(
+        repository.claim_run(date(2026, 7, 9), retry_failed=True)
+    )
+
+    assert claimed is True
+    name, parameters = client.rpc_calls[0]
+    assert name == "claim_orchestration_run"
+    assert parameters["p_source_date"] == "2026-07-09"
+    assert parameters["p_retry_failed"] is True
+    assert parameters["p_run_id"]
+    assert parameters["p_stale_before"].endswith("+00:00")
+
+
+def test_repository_maps_only_profiles_with_nonempty_goals() -> None:
+    rows = [
+        {
+            "id": "profile-1",
+            "user_id": "user-1",
+            "email": "reader@example.com",
+            "name": "Reader",
+            "title": "Researcher",
+            "goals": "Track AI",
+            "interests": "Policy",
+        },
+        {
+            "id": "profile-2",
+            "user_id": "user-2",
+            "email": "empty@example.com",
+            "name": "Empty",
+            "title": None,
+            "goals": None,
+            "interests": None,
+        },
+    ]
+    client = RecordingClient(profile_rows=rows)
+    repository = SupabaseOrchestrationRepository(client)
+
+    profiles = asyncio.run(repository.list_eligible_profiles())
+
+    assert [profile.user_id for profile in profiles] == ["user-1"]
+    assert profiles[0].interests == "Policy"
+    assert ("is", "goals", "null") in client.profile_query.operations
+    assert ("is", "remove", "null") in client.profile_query.operations

--- a/tests/test_orchestration_scheduler.py
+++ b/tests/test_orchestration_scheduler.py
@@ -1,0 +1,50 @@
+"""Behavioral tests for the UTC daily orchestration scheduler."""
+
+import asyncio
+from datetime import datetime, timezone
+
+from src.orchestration_scheduler import DailyOrchestrationScheduler
+
+
+class RecordingOrchestrator:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def run(self, source_date, *, retry_failed=False):
+        self.calls.append((source_date, retry_failed))
+        return "claimed"
+
+
+def test_scheduler_runs_latest_slot_and_catches_up_within_24_hours() -> None:
+    orchestrator = RecordingOrchestrator()
+    scheduler = DailyOrchestrationScheduler(
+        orchestrator, hour_utc=13, catchup_hours=24
+    )
+
+    catchup = asyncio.run(
+        scheduler.tick(datetime(2026, 7, 10, 12, 59, tzinfo=timezone.utc))
+    )
+    current = asyncio.run(
+        scheduler.tick(datetime(2026, 7, 10, 13, 0, tzinfo=timezone.utc))
+    )
+
+    assert catchup == "claimed"
+    assert current == "claimed"
+    assert orchestrator.calls == [
+        (datetime(2026, 7, 8).date(), False),
+        (datetime(2026, 7, 9).date(), False),
+    ]
+
+
+def test_scheduler_does_not_backfill_beyond_catchup_window() -> None:
+    orchestrator = RecordingOrchestrator()
+    scheduler = DailyOrchestrationScheduler(
+        orchestrator, hour_utc=13, catchup_hours=12
+    )
+
+    result = asyncio.run(
+        scheduler.tick(datetime(2026, 7, 10, 12, 59, tzinfo=timezone.utc))
+    )
+
+    assert result is None
+    assert orchestrator.calls == []

--- a/tests/test_resend_email.py
+++ b/tests/test_resend_email.py
@@ -1,0 +1,189 @@
+"""Contract tests for Resend digest delivery."""
+
+import asyncio
+import json
+from datetime import date
+
+import httpx
+
+from src.orchestration import AmbiguousEmailDelivery, Profile
+from src.resend_email import ResendEmailSender
+
+
+def test_resend_sender_uses_stable_idempotency_key_and_digest_metadata() -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"id": "email-123"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    sender = ResendEmailSender(
+        api_key="test-resend-key",
+        from_address="Paperboy Digest <digest@paper-boy.app>",
+        client=client,
+    )
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Ada",
+        title="Researcher",
+        goals="AI",
+        interests=None,
+    )
+
+    email_id = asyncio.run(
+        sender.send_digest(
+            profile=profile,
+            source_date=date(2026, 7, 9),
+            task_id="task-1",
+            html="<html>digest</html>",
+        )
+    )
+    asyncio.run(client.aclose())
+
+    assert email_id == "email-123"
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url == "https://api.resend.com/emails"
+    assert request.headers["authorization"] == "Bearer test-resend-key"
+    assert request.headers["idempotency-key"] == "paperboy:2026-07-09:user-1"
+    assert json.loads(request.content) == {
+        "from": "Paperboy Digest <digest@paper-boy.app>",
+        "to": ["reader@example.com"],
+        "html": "<html>digest</html>",
+        "subject": "Paperboy | Ada's Daily Digest",
+        "tags": [{"name": "task_id", "value": "task-1"}],
+    }
+
+
+def test_transport_failure_is_reported_as_ambiguous_delivery() -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection lost", request=request)
+
+    async def no_wait(seconds: float) -> None:
+        pass
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    sender = ResendEmailSender(
+        api_key="test-resend-key",
+        from_address="Paperboy <digest@paper-boy.app>",
+        client=client,
+        max_attempts=2,
+        sleep=no_wait,
+    )
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Ada",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+
+    try:
+        asyncio.run(
+            sender.send_digest(
+                profile=profile,
+                source_date=date(2026, 7, 9),
+                task_id="task-1",
+                html="<html>digest</html>",
+            )
+        )
+    except AmbiguousEmailDelivery:
+        pass
+    else:
+        raise AssertionError("a lost provider receipt must remain ambiguous")
+    asyncio.run(client.aclose())
+
+
+def test_repeated_server_errors_remain_ambiguous_after_retries() -> None:
+    def handle(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"message": "try again"})
+
+    async def no_wait(seconds: float) -> None:
+        pass
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    sender = ResendEmailSender(
+        api_key="test-resend-key",
+        from_address="Paperboy <digest@paper-boy.app>",
+        client=client,
+        max_attempts=2,
+        sleep=no_wait,
+    )
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Ada",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+
+    try:
+        asyncio.run(
+            sender.send_digest(
+                profile=profile,
+                source_date=date(2026, 7, 9),
+                task_id="task-1",
+                html="<html>digest</html>",
+            )
+        )
+    except AmbiguousEmailDelivery:
+        pass
+    else:
+        raise AssertionError("repeated provider errors must remain ambiguous")
+    asyncio.run(client.aclose())
+
+
+def test_resend_retry_reuses_the_same_idempotency_key() -> None:
+    requests: list[httpx.Request] = []
+    sleeps: list[float] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(503, json={"message": "try again"})
+        return httpx.Response(200, json={"id": "email-123"})
+
+    async def no_wait(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    sender = ResendEmailSender(
+        api_key="test-resend-key",
+        from_address="Paperboy <digest@paper-boy.app>",
+        client=client,
+        retry_delay_seconds=5,
+        sleep=no_wait,
+    )
+    profile = Profile(
+        id="profile-1",
+        user_id="user-1",
+        email="reader@example.com",
+        name="Ada",
+        title=None,
+        goals="AI",
+        interests=None,
+    )
+
+    email_id = asyncio.run(
+        sender.send_digest(
+            profile=profile,
+            source_date=date(2026, 7, 9),
+            task_id="task-1",
+            html="<html>digest</html>",
+        )
+    )
+    asyncio.run(client.aclose())
+
+    assert email_id == "email-123"
+    assert sleeps == [5]
+    assert [r.headers["idempotency-key"] for r in requests] == [
+        "paperboy:2026-07-09:user-1",
+        "paperboy:2026-07-09:user-1",
+    ]

--- a/tests/test_validate_environment.py
+++ b/tests/test_validate_environment.py
@@ -11,7 +11,15 @@ from src.main import validate_environment
 
 def _clear_llm_env(monkeypatch):
     """Start from a clean slate for the vars this function inspects."""
-    for var in ("LLM_PROVIDER", "OPENAI_API_KEY", "FIREWORKS_API_KEY", "API_KEY"):
+    for var in (
+        "LLM_PROVIDER",
+        "OPENAI_API_KEY",
+        "FIREWORKS_API_KEY",
+        "API_KEY",
+        "ORCHESTRATION_ENABLED",
+        "RESEND_API_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+    ):
         monkeypatch.delenv(var, raising=False)
     # Supabase disabled so the function doesn't wander into that branch.
     monkeypatch.setenv("USE_SUPABASE", "false")
@@ -59,6 +67,20 @@ def test_unknown_provider_raises(monkeypatch):
     with pytest.raises(RuntimeError) as excinfo:
         validate_environment()
     assert "anthropic" in str(excinfo.value)
+
+
+def test_enabled_orchestration_requires_backend_only_credentials(monkeypatch):
+    _clear_llm_env(monkeypatch)
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setenv("ORCHESTRATION_ENABLED", "true")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        validate_environment()
+
+    message = str(excinfo.value)
+    assert "RESEND_API_KEY" in message
+    assert "SUPABASE_SERVICE_ROLE_KEY" in message
 
 
 def test_missing_api_key_reported(monkeypatch):


### PR DESCRIPTION
## Summary

Replaces the three production n8n digest workflows with an opt-in coordinator hosted inside the existing always-on Fly.io backend.

- runs the 13:00 UTC daily schedule with a bounded 24-hour catch-up window
- invokes the existing source-fetch and digest services directly (no self-HTTP or callbacks)
- preserves the current profile eligibility and one-minute launch cadence, with bounded overlap
- writes `digest_tasks.user_id` when the task is created so Dashboard linkage no longer depends on n8n
- updates the existing `profiles.task_id`, `started_at`, `task_html`, and `completed_at` contract
- delivers digest HTML through Resend with retries, stable idempotency keys, and ambiguous-receipt protection
- adds durable run/delivery checkpoints, immutable profile snapshots, stale-run takeover, and database fencing
- adds protected manual-run/status endpoints and orchestration readiness checks
- fixes Uvicorn SIGTERM ownership so lifespan teardown and task cancellation run cleanly

The feature remains **disabled by default**, so merging/deploying this PR does not schedule work or send customer email.

## Database and rollout

`docs/supabase_orchestration.sql` adds two backend-owned tables and three service-role-only RPCs. It does not alter a frontend-consumed table. The SQL must be applied manually before enabling the feature.

The complete staged rollout, no-overlap cutover, rollback steps, required Fly secrets, and operational API examples are documented in `docs/backend-orchestration.md`.

Required before `ORCHESTRATION_ENABLED=true`:

- apply `docs/supabase_orchestration.sql`
- set `SUPABASE_SERVICE_ROLE_KEY`
- set `RESEND_API_KEY`
- coordinate disabling n8n workflow 1 with enabling the backend scheduler to prevent duplicate email

## Verification

- `.venv/bin/pytest -q` — **70 passed, 1 skipped**
- `python -m compileall -q src` — passed
- PostgreSQL 16 migration smoke test — schema/RPCs applied successfully; verified first claim, duplicate rejection, stale takeover, composite-FK delivery fencing, immutable snapshot storage, and stale profile-write rejection
- Uvicorn runtime smoke test — `/health` healthy, orchestration routes present in OpenAPI, and SIGTERM completed lifespan shutdown cleanly
- `git diff --check origin/main...HEAD` — clean
- secret-pattern scan — no credentials found

## Review notes

No production schema, Fly secrets, n8n workflows, or deployments were changed as part of this PR.
