### PR TITLE
Fallback when ranking provider returns invalid output

### DIFF
--- a/src/digest_service_enhanced.py
+++ b/src/digest_service_enhanced.py
@@ -1006,6 +1006,16 @@ class EnhancedDigestService:
         except CircuitOpenError:
             logfire.error("Papers ranking circuit breaker open, using fallback")
             return self._create_fallback_ranked(papers[:top_n], "paper")
+        except ValueError as exc:
+            logfire.error(
+                "Paper ranking response was unusable, using fallback: {error}",
+                error=summarize_exception(exc),
+            )
+            return self._create_fallback_ranked(
+                papers[:top_n],
+                "paper",
+                reason="LLM ranking unavailable - default ranking",
+            )
 
     async def _rank_news_separately(
         self,
@@ -1029,9 +1039,25 @@ class EnhancedDigestService:
         except CircuitOpenError:
             logfire.error("News ranking circuit breaker open, using fallback")
             return self._create_fallback_ranked(news_articles[:top_n], "news")
+        except ValueError as exc:
+            logfire.error(
+                "News ranking response was unusable, using fallback: {error}",
+                error=summarize_exception(exc),
+            )
+            return self._create_fallback_ranked(
+                news_articles[:top_n],
+                "news",
+                reason="LLM ranking unavailable - default ranking",
+            )
 
-    def _create_fallback_ranked(self, items: List[Dict[str, Any]], content_type: str) -> List[RankedArticle]:
-        """Create fallback ranked articles when circuit breaker is open."""
+    def _create_fallback_ranked(
+        self,
+        items: List[Dict[str, Any]],
+        content_type: str,
+        *,
+        reason: str = "Circuit breaker active - default ranking",
+    ) -> List[RankedArticle]:
+        """Create deterministic ranked articles when LLM ranking is unavailable."""
         fallback_ranked = []
         for i, item in enumerate(items):
             try:
@@ -1039,7 +1065,7 @@ class EnhancedDigestService:
                     title=item.get('title', 'Unknown'),
                     authors=item.get('authors') or ([item['author']] if item.get('author') else ['Unknown']),
                     subject=item.get('subject', 'news' if content_type == 'news' else 'cs.AI'),
-                    score_reason="Circuit breaker active - default ranking",
+                    score_reason=reason,
                     relevance_score=100 - (i * 10),  # Decreasing scores
                     abstract_url=item.get('abstract_url', item.get('url', 'https://example.com')),
                     html_url=item.get('html_url'),

--- a/tests/test_ranking_fallback.py
+++ b/tests/test_ranking_fallback.py
@@ -93,6 +93,115 @@ def test_paper_ranking_failure_still_completes_when_news_succeeds(service, monke
     assert result_arg == "<html>ok</html>"
 
 
+def test_news_only_digest_uses_deterministic_ranking_when_provider_returns_invalid_json(
+    service, monkeypatch
+):
+    async def fake_load(source_date=None):
+        return {
+            "source_date": "2026-07-12",
+            "arxiv_papers": [],
+            "news_articles": [
+                {
+                    "title": "N1",
+                    "author": "Reporter",
+                    "url": "https://example.com/news/1",
+                    "type": "news",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(service, "_load_daily_sources", fake_load)
+    monkeypatch.setattr(
+        service.llm_client,
+        "rank_news_only",
+        AsyncMock(
+            side_effect=ValueError(
+                "Both structured output and manual parsing failed: Invalid JSON"
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_process_papers_parallel", AsyncMock(return_value=[]))
+
+    processed_news = []
+
+    async def process_news(items, user_info):
+        processed_news.extend(items)
+        return [{"type": "news", "title": item.title} for item in items]
+
+    monkeypatch.setattr(service, "_process_news_parallel", process_news)
+    monkeypatch.setattr(
+        service, "_generate_final_digest", AsyncMock(return_value="<html>ok</html>")
+    )
+
+    complete = AsyncMock()
+    monkeypatch.setattr(service, "_complete_task", complete)
+
+    asyncio.run(
+        service.generate_digest(
+            "task-news-only",
+            {"name": "X"},
+            source_date="2026-07-12",
+            digest_sources={"arxiv": True, "news_api": True},
+        )
+    )
+
+    assert complete.await_args.args[1] == "<html>ok</html>"
+    assert [item.title for item in processed_news] == ["N1"]
+    assert processed_news[0].score_reason == "LLM ranking unavailable - default ranking"
+
+
+def test_paper_only_digest_uses_deterministic_ranking_when_provider_returns_invalid_json(
+    service, monkeypatch
+):
+    async def fake_load(source_date=None):
+        return {
+            "source_date": "2026-07-13",
+            "arxiv_papers": [
+                {
+                    "title": "P1",
+                    "authors": ["Researcher"],
+                    "abstract_url": "https://example.com/paper/1",
+                    "type": "paper",
+                }
+            ],
+            "news_articles": [],
+        }
+
+    monkeypatch.setattr(service, "_load_daily_sources", fake_load)
+    monkeypatch.setattr(
+        service.llm_client,
+        "rank_papers_only",
+        AsyncMock(side_effect=ValueError("Invalid JSON in response")),
+    )
+
+    processed_papers = []
+
+    async def process_papers(items, user_info):
+        processed_papers.extend(items)
+        return [{"type": "paper", "title": item.title} for item in items]
+
+    monkeypatch.setattr(service, "_process_papers_parallel", process_papers)
+    monkeypatch.setattr(service, "_process_news_parallel", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        service, "_generate_final_digest", AsyncMock(return_value="<html>ok</html>")
+    )
+    complete = AsyncMock()
+    monkeypatch.setattr(service, "_complete_task", complete)
+
+    asyncio.run(
+        service.generate_digest(
+            "task-paper-only",
+            {"name": "X"},
+            source_date="2026-07-13",
+            digest_sources={"arxiv": True, "news_api": True},
+        )
+    )
+
+    assert complete.await_args.args[1] == "<html>ok</html>"
+    assert [item.title for item in processed_papers] == ["P1"]
+    assert processed_papers[0].score_reason == "LLM ranking unavailable - default ranking"
+
+
 def test_both_ranking_failures_fail_with_actionable_message(service, monkeypatch):
     _stub_sources(monkeypatch, service)
 


### PR DESCRIPTION
## Summary

- use deterministic source ordering when paper or news ranking returns unusable provider output
- preserve the existing circuit-breaker fallback and source-isolation behavior
- cover news-only weekend digests and paper-only digests through the public digest-generation path

## Production incident

The backend cutover completed successfully, but one news-only digest failed twice because Fireworks returned non-JSON output through both structured and manual parsing. No email was attempted for that recipient. This fallback keeps the digest moving with the first `top_n` source items when ranking raises `ValueError`.

## Verification

- `.venv/bin/pytest -q tests/test_ranking_fallback.py` — 4 passed
- `.venv/bin/pytest -q` — 72 passed, 1 skipped
- `.venv/bin/python -m compileall -q src` — passed
- `git diff --check` — passed
