### PR TITLE
docs: reconcile CLAUDE.md/PROJECT_ARCH with current architecture (partial #15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Paperboy is an AI-powered academic paper recommendation system that ranks and analyzes arXiv papers and news articles based on user research profiles. It uses OpenAI models to provide personalized digests of relevant research papers and industry news. The system includes enhanced reliability features including circuit breakers, Supabase state management, graceful shutdown, and comprehensive error handling.
 
+> **Current architecture (2026-07).** Production runs on **Fly.io** (`paperboy-ai.fly.dev`),
+> **not** Cloud Run (the `deploy_cloudrun.sh`/`cloudbuild.yaml` paths remain but are not the live
+> target). The daily digest is **self-orchestrated in-process** on Fly (`ORCHESTRATION_ENABLED=true`;
+> see `src/orchestration*.py` and `docs/backend-orchestration.md`): at 13:00 UTC it reads `profiles`,
+> generates a digest per active user, writes `digest_tasks` **with `user_id` set directly**, updates
+> `profiles`, and emails via Resend. The old **n8n** workflows and **Pipedream** welcome workflow
+> have been **retired**. The signup **welcome email** is now `POST /hooks/welcome` (Supabase
+> `profiles`-INSERT webhook → Resend; see `docs/welcome-email.md`). A **delivery-failure monitor**
+> runs as a Supabase **pg_cron** job (`digest-health-check`, 15:00 UTC). Many "Cloud Run" mentions
+> below are historical.
+
 **Key Features:**
 
 - **Mixed Content Sources**: ArXiv papers + NewsAPI articles ranked together
@@ -243,7 +254,7 @@ Production containers implement:
 - Content extraction is prioritized for high-relevance articles
 - The archived full implementation with Playwright/crawl4ai is in `archived/`
 - **Missing Supabase Schema**: The deployment mentions `supabase_setup.sql` but this file doesn't exist - you'll need to create tables manually (including `daily_sources` and `fetch_tasks` for the fetch service)
-- **Pipedream Integration**: There's a webhook integration in `pipedream/trigger-generate-digest.js` for batch user processing
+- **~~Pipedream Integration~~ (retired 2026-07)**: The old `pipedream/trigger-generate-digest.js` webhook and the separate Pipedream welcome-email workflow are no longer used. Batch digest runs are handled in-process by the backend orchestrator (`src/orchestration*.py`); the welcome email is `POST /hooks/welcome` (see `docs/welcome-email.md`).
 
 ### Common Development Tasks
 

--- a/PROJECT_ARCH.md
+++ b/PROJECT_ARCH.md
@@ -31,8 +31,18 @@ The system addresses the information overload problem faced by researchers and t
 - **State Management**: Supabase (distributed) with in-memory fallback
 - **Reliability**: Circuit breakers, graceful shutdown, retry logic
 - **Containerization**: Docker with security hardening
-- **Deployment**: Google Cloud Run with auto-scaling
-- **Monitoring**: Logfire for production observability
+- **Deployment**: **Fly.io** (prod: `paperboy-ai.fly.dev`). Cloud Run scripts (`deploy_cloudrun.sh`, `cloudbuild.yaml`) remain in the repo but are **not** the live target.
+- **Monitoring**: Logfire for production observability; a Supabase **pg_cron** job (`digest-health-check`, 15:00 UTC) emails a Resend alert if <90% of the active cohort received a digest.
+
+> **Current architecture (2026-07).** Beyond the request/response API described below, the backend
+> **self-orchestrates the daily digest in-process** on Fly (`ORCHESTRATION_ENABLED=true`; see
+> `src/orchestration*.py` and `docs/backend-orchestration.md`). At 13:00 UTC it selects `profiles`
+> where `goals` is not null and `remove` is null, generates one digest per user (durable, idempotent
+> state in `orchestration_runs` / `orchestration_deliveries`), writes `digest_tasks` **with `user_id`
+> set directly**, updates `profiles`, and emails via Resend (`digest@paper-boy.app`). The signup
+> **welcome email** is `POST /hooks/welcome`, fired by a Supabase `profiles`-INSERT webhook (see
+> `docs/welcome-email.md`). The former **n8n** orchestration and **Pipedream** welcome workflows
+> have been retired. "Cloud Run" references elsewhere in this document are historical.
 
 ## Architecture Overview
 


### PR DESCRIPTION
Partial progress on #15 — corrects the docs facts that the **n8n → Fly** migration and welcome-email/monitor work made stale.

## Changes
Adds a dated **"Current architecture (2026-07)"** note to `CLAUDE.md` and `PROJECT_ARCH.md`, and fixes the most misleading specifics:

- **Prod is Fly.io, not Cloud Run** (the `deploy_cloudrun.sh`/`cloudbuild.yaml` paths remain but aren't the live target).
- **Daily digest is self-orchestrated in-process** on Fly (`src/orchestration*.py`, `ORCHESTRATION_ENABLED=true`) — no external n8n workflows.
- **`digest_tasks.user_id` is written directly by the backend** now (the old n8n back-fill is gone — see #7).
- **Welcome email** = `POST /hooks/welcome` (Supabase `profiles`-INSERT webhook → Resend), replacing the retired **Pipedream** workflow. The stale `pipedream/trigger-generate-digest.js` bullet is marked retired.
- **Delivery-failure monitor** = Supabase **pg_cron** job `digest-health-check` (15:00 UTC).

## Scope / what remains for #15
This is intentionally **targeted** (migration facts), not a full rewrite. Remaining staleness — the many historical "Cloud Run" mentions scattered through `PROJECT_ARCH.md`, and any other drift — is flagged inline as historical and left for a fuller sweep under #15.

Docs-only; no code or deploy impact.