### PR TITLE
feat: measure digest link quality before adding UI labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Configuration is loaded from `config/.env` (see `config/.env.example`).
 - `SENTRY_DSN` (optional): enables backend error reporting to Sentry. Unset = disabled (no-op). No PII is sent — `send_default_pii=False` and user/request contexts are stripped before send. Requires `sentry-sdk` (declared in requirements); if absent the backend logs a warning and stays disabled.
 - `SENTRY_ENVIRONMENT` (optional, default `production`): environment tag for Sentry events
 - `WELCOME_FROM_ADDRESS` (default: `Welcome <hello@paper-boy.app>`): verified Resend sender for the signup welcome email sent by `POST /hooks/welcome`. Requires `RESEND_API_KEY`. See [`docs/welcome-email.md`](docs/welcome-email.md).
+- `FEEDBACK_CTA_ENABLED` (default: `true`): show the temporary Tally feedback CTA in newly rendered digest HTML. Set `false` after the feedback window. `FEEDBACK_FORM_URL` overrides the default Tally URL. See [`docs/link-quality-observability.md`](docs/link-quality-observability.md).
 - `ORCHESTRATION_ENABLED` (default: `false`): enables the backend-hosted daily scheduler that replaces n8n. It requires `SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, and the schema in [`docs/supabase_orchestration.sql`](docs/supabase_orchestration.sql). See the [backend orchestration rollout guide](docs/backend-orchestration.md).
 
 ### LLM provider (OpenAI or Fireworks)

--- a/config/.env.example
+++ b/config/.env.example
@@ -61,6 +61,11 @@ ORCHESTRATION_STALE_AFTER_MINUTES=120
 # RESEND_API_KEY=your-resend-api-key
 RESEND_FROM_ADDRESS="Paperboy Digest <digest@paper-boy.app>"
 
+# Temporary feedback CTA in newly rendered digest HTML. Disable after the
+# feedback window without changing templates.
+FEEDBACK_CTA_ENABLED=true
+FEEDBACK_FORM_URL=https://tally.so/r/A7G02o
+
 # API key for Paperboy Endpoints
 API_KEY=
 

--- a/docs/link-quality-observability.md
+++ b/docs/link-quality-observability.md
@@ -1,0 +1,79 @@
+# Digest link-quality observability
+
+## Why this exists
+
+Initial user feedback identified broken and paywalled links as a repeated pain
+point. Before changing article UI or filtering sources, the backend measures the
+news links selected during daily digest generation.
+
+This is **observability only**. It does not suppress articles, add badges, alter
+ranking, or make a second request to a publisher.
+
+## Measurement path
+
+The production digest already sends each selected news URL to Tavily Extract for
+summary content. A deterministic Tavily target result is requested once; transient
+transport/429/5xx provider failures retain one bounded retry. Two consecutive 429s open
+an in-process circuit for the rest of the UTC day, preventing quota hammering; it resets
+automatically the next day. No publisher HEAD/GET probe is added. `TavilyExtractor.extract_single_with_quality()` consumes the
+same response's `results` and `failed_results` fields and classifies it as:
+
+- `accessible`: extracted content passed the existing 100-character threshold;
+- `suspected_paywall`: extracted content or an explicit Tavily failure contains
+  a conservative subscription/sign-in/paywall marker;
+- `broken`: an explicit terminal failure such as 404, 410, invalid URL/host, or
+  DNS name-resolution failure;
+- `unknown`: ambiguous access denial, timeout, provider error, bot protection,
+  short/empty content, no extractor, or malformed response.
+
+`unknown` is intentional: ambiguous 401/403/5xx responses are not guessed to be
+paywalls or broken links. Redirect rate is not measured because Tavily does not
+provide a reliable redirect chain/final URL. Measuring redirects would require
+another publisher request, which this change deliberately avoids.
+
+## Logfire event
+
+`EnhancedDigestService._process_news_parallel()` emits one structured event per
+digest:
+
+```text
+message = "Digest link quality measured"
+schema_version = 1
+measurement_scope = "selected_news_links"
+attempted_count
+accessible_count / accessible_pct
+suspected_paywall_count / suspected_paywall_pct
+broken_count / broken_pct
+unknown_count / unknown_pct
+extraction_success_count
+```
+
+Filter Logfire on the exact message, then aggregate counts/percentages over at
+least 7–14 production runs before making a product decision. The event contains
+no URL, domain, title, article body, user/task ID, email, profile information, or
+raw provider error.
+
+Percentages measure **selected-link generation attempts**, not confirmed recipient
+exposure or unique publisher URLs. A later rendering/delivery failure can prevent a
+measured link from reaching the recipient, and retries can measure it again. The same
+URL appearing in several personalized digests is counted several times by design.
+
+## Feedback CTA
+
+New Jinja-rendered digests include a small `Help shape Paperboy` link to
+`https://tally.so/r/A7G02o` before the footer. Email and Dashboard share the same
+stored HTML. Set `FEEDBACK_CTA_ENABLED=false` to end the feedback window without
+a template change; `FEEDBACK_FORM_URL` overrides the destination.
+
+The rare LLM/fallback HTML path does not include the CTA. The CTA never blocks
+digest generation.
+
+## Decision rule
+
+Do not add UI labels based on individual heuristic classifications. First review
+aggregate production data and manually audit a sample of links. If the signal is
+material:
+
+1. validate suspected-paywall precision against a sample;
+2. decide whether to label, filter, or substitute accessible sources;
+3. separately investigate `unknown` if it dominates the metric.

--- a/src/config.py
+++ b/src/config.py
@@ -64,6 +64,15 @@ class Settings(BaseSettings):
         validation_alias="INLINE_EMAIL_CSS",
         description="Inline CSS into rendered email HTML for better client compatibility"
     )
+    feedback_cta_enabled: bool = Field(
+        default=True,
+        validation_alias="FEEDBACK_CTA_ENABLED",
+        description="Show the temporary Tally feedback CTA in new digest HTML",
+    )
+    feedback_form_url: str = Field(
+        default="https://tally.so/r/A7G02o",
+        validation_alias="FEEDBACK_FORM_URL",
+    )
 
     logfire_token: Optional[str] = Field(default=None, validation_alias='LOGFIRE_TOKEN', description="Logfire token for monitoring")
 

--- a/src/content_extractor.py
+++ b/src/content_extractor.py
@@ -1,11 +1,22 @@
 import asyncio
-from typing import List, Dict, Any, Optional
+from datetime import date, datetime, timezone
+from typing import Awaitable, Callable, List, Dict, Any, Optional
+import httpx
 import logfire
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 from .config import settings
 from .metrics import NewsMetrics
 from .http_utils import create_http_client
+from .link_quality import (
+    LinkAccessStatus,
+    LinkQualityOutcome,
+    classify_tavily_result,
+)
+
+def _utc_today() -> date:
+    return datetime.now(timezone.utc).date()
+
 
 class ContentExtractionError(Exception):
     """Content extraction failed"""
@@ -14,16 +25,27 @@ class ContentExtractionError(Exception):
 class TavilyExtractor:
     """Extracts full content with rate limiting and batch processing."""
     
-    def __init__(self):
+    def __init__(
+        self,
+        client: httpx.AsyncClient | None = None,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        today: Callable[[], date] = _utc_today,
+    ):
         if not settings.tavily_api_key:
             raise ValueError("Tavily API key not configured")
-        
+
         self.api_key = settings.tavily_api_key
         self.base_url = "https://api.tavily.com/extract"
         self.semaphore = asyncio.Semaphore(settings.extract_max_concurrent)
         self._request_count = 0
         self._request_limit = 100  # Assumed daily limit
-        self.client = create_http_client(read_timeout=settings.extract_timeout or 25.0)
+        self.client = client or create_http_client(
+            read_timeout=settings.extract_timeout or 25.0
+        )
+        self._owns_client = client is None
+        self._sleep = sleep
+        self._today = today
+        self._rate_limited_on: date | None = None
     
     @NewsMetrics.track_content_extraction
     async def extract_articles(
@@ -86,18 +108,81 @@ class TavilyExtractor:
         return result
     
     async def extract_single(self, url: str) -> Optional[Dict[str, Any]]:
-        """Extract content for a single URL with circuit breaker protection."""
-        if self._request_count >= self._request_limit:
-            logfire.warn("Tavily request limit reached, returning None")
+        """Backward-compatible content extraction for callers not using quality data."""
+        outcome = await self.extract_single_with_quality(url)
+        if not outcome.extraction_success:
             return None
-        
-        try:
-            content = await self._extract_single(url)
-            self._request_count += 1
-            return {'content': content, 'extraction_success': True}
-        except Exception as e:
-            logfire.error(f"Failed to extract content for {url}: {str(e)}")
-            return None
+        return {"content": outcome.content, "extraction_success": True}
+
+    async def extract_single_with_quality(self, url: str) -> LinkQualityOutcome:
+        """Extract and classify one link from a single Tavily request.
+
+        Classification consumes only the response already needed for summary
+        generation. It never probes the publisher URL and never logs the URL,
+        title, body, or raw provider error.
+        """
+        if self._rate_limited_on == self._today():
+            return LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False)
+
+        for attempt in range(2):
+            try:
+                response = await self.client.post(
+                    self.base_url,
+                    json={
+                        "api_key": self.api_key,
+                        "urls": [url],
+                        "include_images": False,
+                        "include_links": False,
+                        "include_formatting": False,
+                    },
+                )
+                self._request_count += 1
+
+                # Preserve one bounded retry for transient provider failures.
+                # Deterministic target failures (including failed_results) are
+                # classified from this response and never fetched again.
+                if (response.status_code == 429 or response.status_code >= 500) and attempt == 0:
+                    await self._sleep(1)
+                    continue
+                if response.status_code == 429:
+                    self._rate_limited_on = self._today()
+                response.raise_for_status()
+                data = response.json()
+                if not isinstance(data, dict):
+                    return LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False)
+
+                results = data.get("results") or []
+                if not isinstance(results, list):
+                    return LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False)
+                content = ""
+                if results:
+                    first = results[0]
+                    if not isinstance(first, dict):
+                        return LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False)
+                    content = first.get("raw_content", "") or first.get("content", "")
+                    if not isinstance(content, str):
+                        content = ""
+
+                failed_results = data.get("failed_results") or []
+                failure_error = None
+                if isinstance(failed_results, list) and failed_results:
+                    first_failure = failed_results[0]
+                    if isinstance(first_failure, dict):
+                        failure_error = str(first_failure.get("error") or "")
+
+                return classify_tavily_result(
+                    content=content,
+                    failure_error=failure_error,
+                )
+            except httpx.TransportError:
+                if attempt == 0:
+                    await self._sleep(1)
+                    continue
+            except (httpx.HTTPStatusError, ValueError, TypeError):
+                pass
+            return LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False)
+
+        return LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False)
     
     async def _batch_extract(self, articles: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Extract articles in batches."""
@@ -187,5 +272,6 @@ class TavilyExtractor:
         return articles
     
     async def close(self):
-        """Close the HTTP client."""
-        await self.client.aclose()
+        """Close the internally owned HTTP client."""
+        if self._owns_client:
+            await self.client.aclose()

--- a/src/digest_service_enhanced.py
+++ b/src/digest_service_enhanced.py
@@ -17,6 +17,11 @@ from .state_supabase import TaskStateManager
 from .config import settings
 from .news_fetcher import NewsAPIFetcher
 from .content_extractor import TavilyExtractor
+from .link_quality import (
+    LinkAccessStatus,
+    LinkQualityOutcome,
+    emit_link_quality_summary,
+)
 from .circuit_breaker import ServiceCircuitBreakers, CircuitOpenError
 from .fetch_service import DailySourcesManager
 from .http_utils import send_webhook_callback
@@ -44,6 +49,7 @@ class EnhancedDigestService:
             self.circuit_breakers = None
         
         self.cache = None  # Will be injected from main.py
+        self.link_quality_reporter = emit_link_quality_summary
         
         # Initialize news components only if enabled
         self.news_fetcher = None
@@ -1146,24 +1152,36 @@ class EnhancedDigestService:
         
         semaphore = asyncio.Semaphore(settings.summary_max_concurrent)
         
-        async def process_single_news(article: RankedArticle) -> Dict[str, Any]:
+        async def process_single_news(
+            article: RankedArticle,
+        ) -> tuple[Dict[str, Any], LinkQualityOutcome]:
             async with semaphore:
+                quality = LinkQualityOutcome(
+                    status=LinkAccessStatus.UNKNOWN,
+                    extraction_success=False,
+                )
                 try:
-                    # Try Tavily extraction if available
+                    # Reuse the Tavily request already made for summarization to
+                    # classify accessibility. Never probe the publisher URL.
                     full_content = ""
                     if self.content_extractor:
                         try:
-                            extracted = await self.content_extractor.extract_single(str(article.abstract_url))
-                            if extracted:
-                                full_content = extracted.get('content', '')
-                                logfire.info(f"Successfully extracted content for {article.title}")
-                        except Exception as e:
-                            logfire.warn(f"Tavily extraction failed for {article.title}: {str(e)}")
-                    
+                            quality = await self.content_extractor.extract_single_with_quality(
+                                str(article.abstract_url)
+                            )
+                            if quality.extraction_success:
+                                full_content = quality.content
+                        except Exception:
+                            # Extraction observability must never prevent the
+                            # existing preview-based summary fallback.
+                            quality = LinkQualityOutcome(
+                                LinkAccessStatus.UNKNOWN, False
+                            )
+                            logfire.warn("Tavily extraction unavailable; using preview")
+
                     # Fallback to preview content if extraction failed
                     if not full_content:
                         full_content = article.score_reason  # Use score reason as preview
-                        logfire.info(f"Using preview content for {article.title}")
                     
                     # Convert RankedArticle to dict for summarization
                     article_dict = {
@@ -1184,10 +1202,10 @@ class EnhancedDigestService:
                         full_content,
                         user_info
                     )
-                    return summary
+                    return summary, quality
                 except Exception as e:
                     logfire.error(f"Failed to process news article {article.title}: {str(e)}")
-                    return {
+                    return ({
                         'title': article.title,
                         'source': getattr(article, 'source', 'Unknown'),
                         'type': 'news',
@@ -1197,16 +1215,31 @@ class EnhancedDigestService:
                         'action_item': 'Read full article',
                         'relevance_score': article.relevance_score,
                         'url': str(article.abstract_url)
-                    }
-        
+                    }, quality)
+
         # Process all news articles in parallel
         tasks = [process_single_news(article) for article in news_articles]
-        summaries = await asyncio.gather(*tasks, return_exceptions=True)
-        
-        # Filter out exceptions
-        valid_summaries = [s for s in summaries if not isinstance(s, Exception)]
+        processed = await asyncio.gather(*tasks, return_exceptions=True)
+
+        valid_summaries: List[Dict[str, Any]] = []
+        quality_outcomes: List[LinkQualityOutcome] = []
+        for item in processed:
+            if isinstance(item, Exception):
+                quality_outcomes.append(
+                    LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False)
+                )
+                continue
+            summary, quality = item
+            valid_summaries.append(summary)
+            quality_outcomes.append(quality)
+
+        if quality_outcomes:
+            reporter = getattr(
+                self, "link_quality_reporter", emit_link_quality_summary
+            )
+            reporter(quality_outcomes)
         logfire.info(f"Processed {len(valid_summaries)} news summaries")
-        
+
         return valid_summaries
 
     async def _generate_final_digest(

--- a/src/email_renderer.py
+++ b/src/email_renderer.py
@@ -36,6 +36,9 @@ def _get_env() -> Environment:
         # Make theme tokens available to all templates/macros.
         _env.globals["theme"] = THEME
         logfire.info(f"Initialized Jinja2 environment with templates from: {TEMPLATES_DIR}")
+    _env.globals["feedback_cta_url"] = (
+        settings.feedback_form_url if settings.feedback_cta_enabled else None
+    )
     return _env
 
 

--- a/src/link_quality.py
+++ b/src/link_quality.py
@@ -1,0 +1,113 @@
+"""Privacy-safe link accessibility classification from existing extraction evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+from typing import Any, Callable
+
+import logfire
+
+
+_PAYWALL_PATTERN = re.compile(
+    r"(?:subscribe|subscription) (?:to continue|to read|required)|"
+    r"already a subscriber|subscriber[- ]only|"
+    r"(?:sign in|log in|register) to continue reading|"
+    r"(?:sign[- ]in|login) required",
+    re.IGNORECASE,
+)
+_BROKEN_PATTERN = re.compile(
+    r"(?:http(?: status)?\s*)?(?:404|410)\b|"
+    r"\b(?:page|resource) not found\b|"
+    r"\bdns (?:name )?resolution failed\b|"
+    r"\bno such host\b|\binvalid (?:url|host)\b",
+    re.IGNORECASE,
+)
+
+
+class LinkAccessStatus(str, Enum):
+    ACCESSIBLE = "accessible"
+    SUSPECTED_PAYWALL = "suspected_paywall"
+    BROKEN = "broken"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class LinkQualityOutcome:
+    status: LinkAccessStatus
+    extraction_success: bool
+    content: str = ""
+
+
+def summarize_link_quality(outcomes: list[LinkQualityOutcome]) -> dict[str, int | float | str]:
+    """Build the bounded aggregate event recorded for one digest."""
+    total = len(outcomes)
+    counts = {
+        status: sum(1 for outcome in outcomes if outcome.status is status)
+        for status in LinkAccessStatus
+    }
+
+    def percentage(status: LinkAccessStatus) -> float:
+        return round((counts[status] / total) * 100, 1) if total else 0.0
+
+    return {
+        "schema_version": 1,
+        "measurement_scope": "selected_news_links",
+        "attempted_count": total,
+        "accessible_count": counts[LinkAccessStatus.ACCESSIBLE],
+        "suspected_paywall_count": counts[LinkAccessStatus.SUSPECTED_PAYWALL],
+        "broken_count": counts[LinkAccessStatus.BROKEN],
+        "unknown_count": counts[LinkAccessStatus.UNKNOWN],
+        "extraction_success_count": sum(
+            1 for outcome in outcomes if outcome.extraction_success
+        ),
+        "accessible_pct": percentage(LinkAccessStatus.ACCESSIBLE),
+        "suspected_paywall_pct": percentage(LinkAccessStatus.SUSPECTED_PAYWALL),
+        "broken_pct": percentage(LinkAccessStatus.BROKEN),
+        "unknown_pct": percentage(LinkAccessStatus.UNKNOWN),
+    }
+
+
+def emit_link_quality_summary(
+    outcomes: list[LinkQualityOutcome],
+    *,
+    emit: Callable[..., Any] | None = None,
+) -> dict[str, int | float | str]:
+    """Emit exactly one bounded event and return its attributes."""
+    summary = summarize_link_quality(outcomes)
+    emitter = emit or logfire.info
+    emitter("Digest link quality measured", **summary)
+    return summary
+
+
+def classify_tavily_result(
+    *, content: str = "", failure_error: str | None = None
+) -> LinkQualityOutcome:
+    """Classify one target using only Tavily's existing response evidence."""
+    failure_evidence = failure_error or ""
+    content_evidence = content[:1000]
+    has_extractable_content = len(content.strip()) >= 100
+    if _PAYWALL_PATTERN.search(f"{failure_evidence}\n{content_evidence}"):
+        return LinkQualityOutcome(
+            status=LinkAccessStatus.SUSPECTED_PAYWALL,
+            extraction_success=has_extractable_content,
+            content=content,
+        )
+    if _BROKEN_PATTERN.search(failure_evidence):
+        return LinkQualityOutcome(
+            status=LinkAccessStatus.BROKEN,
+            extraction_success=False,
+            content=content,
+        )
+    if has_extractable_content:
+        return LinkQualityOutcome(
+            status=LinkAccessStatus.ACCESSIBLE,
+            extraction_success=True,
+            content=content,
+        )
+    return LinkQualityOutcome(
+        status=LinkAccessStatus.UNKNOWN,
+        extraction_success=False,
+        content=content,
+    )

--- a/templates/email/components/feedback_cta.jinja
+++ b/templates/email/components/feedback_cta.jinja
@@ -1,0 +1,19 @@
+{% macro render_feedback_cta(url) -%}
+  <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="width:100%; margin-top: {{ theme.spacing['24'] }};">
+    <tr>
+      <td style="padding: {{ theme.spacing['16'] }}; background-color: {{ theme.colors.callout_bg }}; border: 1px solid {{ theme.colors.border }}; text-align: center;">
+        <div class="email-h3" style="font-family: {{ theme.type.font_heading }}; font-size: {{ theme.type.sizes.lg }}; font-weight: 800; color: {{ theme.colors.text }};">
+          Help shape Paperboy
+        </div>
+        <div class="email-muted" style="margin-top: {{ theme.spacing['6'] }}; font-family: {{ theme.type.font_body }}; font-size: {{ theme.type.sizes.sm }}; line-height: {{ theme.type.line_height.normal }}; color: {{ theme.colors.muted_text }};">
+          Was today&rsquo;s digest useful? Tell us what to improve.
+        </div>
+        <div style="margin-top: {{ theme.spacing['10'] }};">
+          <a href="{{ url }}" target="_blank" rel="noopener noreferrer" style="font-family: {{ theme.type.font_body }}; font-size: {{ theme.type.sizes.sm }}; font-weight: 700; text-decoration: underline; color: {{ theme.colors.link }};">
+            Share feedback &rarr;
+          </a>
+        </div>
+      </td>
+    </tr>
+  </table>
+{%- endmacro %}

--- a/templates/email/digest.html.jinja
+++ b/templates/email/digest.html.jinja
@@ -4,6 +4,7 @@
 {% from "components/section_title.jinja" import section_title %}
 {% from "components/article.jinja" import render_article %}
 {% from "components/footer.jinja" import render_footer %}
+{% from "components/feedback_cta.jinja" import render_feedback_cta %}
 
 {% block title %}Paperboy Digest - {{ date }}{% endblock %}
 
@@ -71,5 +72,8 @@
     </table>
   {% endif %}
 
+  {% if feedback_cta_url %}
+    {{ render_feedback_cta(feedback_cta_url) }}
+  {% endif %}
   {{ render_footer(stats) }}
 {% endblock %}

--- a/tests/test_email_feedback_cta.py
+++ b/tests/test_email_feedback_cta.py
@@ -1,0 +1,53 @@
+"""Digest rendering contract for the Paperboy feedback CTA."""
+
+from src.config import settings
+from src.email_renderer import render_digest_html
+from src.models import DigestEmailData, DigestStats
+
+
+def test_digest_renders_feedback_cta_before_footer() -> None:
+    digest = DigestEmailData(
+        date="July 16, 2026",
+        user_name="Ada",
+        user_title="Researcher",
+        stats=DigestStats(),
+    )
+
+    html = render_digest_html(digest)
+
+    assert html.count("https://tally.so/r/A7G02o") == 1
+    assert "Help shape Paperboy" in html
+    assert html.index("Help shape Paperboy") < html.index("Your Research Impact This Week")
+    assert 'target="_blank"' in html
+    assert 'rel="noopener noreferrer"' in html
+
+
+def test_feedback_cta_can_be_disabled_without_changing_the_template(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "feedback_cta_enabled", False)
+    digest = DigestEmailData(
+        date="July 16, 2026",
+        user_name="Ada",
+        user_title="Researcher",
+        stats=DigestStats(),
+    )
+
+    html = render_digest_html(digest)
+
+    assert "https://tally.so/r/A7G02o" not in html
+    assert "Help shape Paperboy" not in html
+
+
+def test_feedback_cta_uses_configured_form_url(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "feedback_cta_enabled", True)
+    monkeypatch.setattr(settings, "feedback_form_url", "https://tally.so/r/NEW123")
+    digest = DigestEmailData(
+        date="July 16, 2026",
+        user_name="Ada",
+        user_title="Researcher",
+        stats=DigestStats(),
+    )
+
+    html = render_digest_html(digest)
+
+    assert "https://tally.so/r/NEW123" in html
+    assert "https://tally.so/r/A7G02o" not in html

--- a/tests/test_link_quality.py
+++ b/tests/test_link_quality.py
@@ -1,0 +1,313 @@
+"""Behavioral tests for privacy-safe link-quality classification."""
+
+import asyncio
+
+import httpx
+
+from src.config import settings
+from src.content_extractor import TavilyExtractor
+from src.digest_service_enhanced import EnhancedDigestService
+from src.models import ContentType, RankedArticle
+from src.link_quality import (
+    LinkAccessStatus,
+    LinkQualityOutcome,
+    classify_tavily_result,
+    emit_link_quality_summary,
+    summarize_link_quality,
+)
+
+
+def test_valid_extracted_content_is_accessible() -> None:
+    outcome = classify_tavily_result(
+        content="A complete article body. " * 20,
+        failure_error=None,
+    )
+
+    assert outcome.status is LinkAccessStatus.ACCESSIBLE
+    assert outcome.extraction_success is True
+
+
+def test_explicit_paywall_evidence_is_classified_conservatively() -> None:
+    failed = classify_tavily_result(
+        failure_error="Unable to extract: subscription required to continue reading"
+    )
+    teaser = classify_tavily_result(
+        content="Subscribe to continue reading this article. Already a subscriber? Sign in."
+    )
+
+    assert failed.status is LinkAccessStatus.SUSPECTED_PAYWALL
+    assert teaser.status is LinkAccessStatus.SUSPECTED_PAYWALL
+    assert failed.extraction_success is False
+    assert teaser.extraction_success is False
+
+    full_but_paywalled = classify_tavily_result(
+        content="Subscribe to continue reading. " + ("Useful extracted article text. " * 20)
+    )
+    assert full_but_paywalled.status is LinkAccessStatus.SUSPECTED_PAYWALL
+    assert full_but_paywalled.extraction_success is True
+
+
+def test_terminal_link_failures_are_broken_but_ambiguous_failures_are_unknown() -> None:
+    for error in (
+        "HTTP 404: page not found",
+        "HTTP 410: resource gone",
+        "DNS name resolution failed",
+        "Invalid host in URL",
+    ):
+        assert classify_tavily_result(failure_error=error).status is LinkAccessStatus.BROKEN
+
+    for error in ("HTTP 403: access denied", "request timed out", "provider returned 503"):
+        assert classify_tavily_result(failure_error=error).status is LinkAccessStatus.UNKNOWN
+
+    article_prose = "A study of 404 participants and the phrase page not found. " * 10
+    assert classify_tavily_result(content=article_prose).status is LinkAccessStatus.ACCESSIBLE
+
+
+def test_extractor_classifies_failed_result_without_a_second_fetch(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "results": [],
+                "failed_results": [
+                    {
+                        "url": "https://publisher.example/story",
+                        "error": "Subscription required to continue reading",
+                    }
+                ],
+                "request_id": "req-1",
+            },
+        )
+
+    monkeypatch.setattr(settings, "tavily_api_key", "test-key")
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    extractor = TavilyExtractor(client=client)
+
+    outcome = asyncio.run(
+        extractor.extract_single_with_quality("https://publisher.example/story")
+    )
+    asyncio.run(client.aclose())
+
+    assert outcome.status is LinkAccessStatus.SUSPECTED_PAYWALL
+    assert outcome.extraction_success is False
+    assert len(requests) == 1
+
+
+def test_extractor_treats_malformed_response_as_unknown(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=["not", "an", "object"])
+
+    monkeypatch.setattr(settings, "tavily_api_key", "test-key")
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    extractor = TavilyExtractor(client=client)
+
+    outcome = asyncio.run(
+        extractor.extract_single_with_quality("https://publisher.example/story")
+    )
+    asyncio.run(client.aclose())
+
+    assert outcome.status is LinkAccessStatus.UNKNOWN
+    assert outcome.extraction_success is False
+    assert len(requests) == 1
+
+
+def test_extractor_retries_one_transient_provider_failure(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(503, json={"error": "temporary"})
+        return httpx.Response(
+            200,
+            json={"results": [{"content": "Recovered article body. " * 20}]},
+        )
+
+    async def no_wait(seconds: float) -> None:
+        pass
+
+    monkeypatch.setattr(settings, "tavily_api_key", "test-key")
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    extractor = TavilyExtractor(client=client, sleep=no_wait)
+
+    outcome = asyncio.run(
+        extractor.extract_single_with_quality("https://publisher.example/story")
+    )
+    asyncio.run(client.aclose())
+
+    assert outcome.status is LinkAccessStatus.ACCESSIBLE
+    assert outcome.extraction_success is True
+    assert len(requests) == 2
+
+
+def test_extractor_retries_one_rate_limit_response(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(429, json={"error": "rate limited"})
+        return httpx.Response(
+            200,
+            json={"results": [{"content": "Recovered article body. " * 20}]},
+        )
+
+    async def no_wait(seconds: float) -> None:
+        pass
+
+    monkeypatch.setattr(settings, "tavily_api_key", "test-key")
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    extractor = TavilyExtractor(client=client, sleep=no_wait)
+
+    outcome = asyncio.run(
+        extractor.extract_single_with_quality("https://publisher.example/story")
+    )
+    asyncio.run(client.aclose())
+
+    assert outcome.status is LinkAccessStatus.ACCESSIBLE
+    assert len(requests) == 2
+
+
+def test_repeated_rate_limit_suppresses_more_requests_for_the_utc_day(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(429, json={"error": "rate limited"})
+
+    async def no_wait(seconds: float) -> None:
+        pass
+
+    monkeypatch.setattr(settings, "tavily_api_key", "test-key")
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    extractor = TavilyExtractor(client=client, sleep=no_wait)
+
+    first = asyncio.run(
+        extractor.extract_single_with_quality("https://publisher.example/one")
+    )
+    second = asyncio.run(
+        extractor.extract_single_with_quality("https://publisher.example/two")
+    )
+    asyncio.run(client.aclose())
+
+    assert first.status is LinkAccessStatus.UNKNOWN
+    assert second.status is LinkAccessStatus.UNKNOWN
+    assert len(requests) == 2  # first attempt + one retry; second URL is suppressed
+
+
+def test_summary_reports_percentages_without_link_or_user_data() -> None:
+    outcomes = [
+        LinkQualityOutcome(LinkAccessStatus.ACCESSIBLE, True),
+        LinkQualityOutcome(LinkAccessStatus.ACCESSIBLE, True),
+        LinkQualityOutcome(LinkAccessStatus.SUSPECTED_PAYWALL, False),
+        LinkQualityOutcome(LinkAccessStatus.BROKEN, False),
+        LinkQualityOutcome(LinkAccessStatus.UNKNOWN, False),
+    ]
+
+    summary = summarize_link_quality(outcomes)
+
+    assert summary == {
+        "schema_version": 1,
+        "measurement_scope": "selected_news_links",
+        "attempted_count": 5,
+        "accessible_count": 2,
+        "suspected_paywall_count": 1,
+        "broken_count": 1,
+        "unknown_count": 1,
+        "extraction_success_count": 2,
+        "accessible_pct": 40.0,
+        "suspected_paywall_pct": 20.0,
+        "broken_pct": 20.0,
+        "unknown_pct": 20.0,
+    }
+    assert not ({"url", "domain", "title", "email", "user_id", "task_id"} & summary.keys())
+
+
+def test_emitter_records_one_bounded_privacy_safe_event() -> None:
+    events: list[tuple[str, dict]] = []
+
+    def record(message: str, **attributes) -> None:
+        events.append((message, attributes))
+
+    outcomes = [
+        LinkQualityOutcome(LinkAccessStatus.ACCESSIBLE, True),
+        LinkQualityOutcome(LinkAccessStatus.BROKEN, False),
+    ]
+    emit_link_quality_summary(outcomes, emit=record)
+
+    assert len(events) == 1
+    message, attributes = events[0]
+    assert message == "Digest link quality measured"
+    assert attributes["attempted_count"] == 2
+    assert attributes["broken_pct"] == 50.0
+    serialized = repr(attributes).lower()
+    for forbidden in ("https://", "publisher", "email", "user_id", "task_id"):
+        assert forbidden not in serialized
+
+
+def test_news_processing_falls_back_and_reports_one_aggregate_event() -> None:
+    class Extractor:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def extract_single_with_quality(self, url: str) -> LinkQualityOutcome:
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("unexpected extractor defect")
+            return LinkQualityOutcome(LinkAccessStatus.BROKEN, False)
+
+    class LLM:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def summarize_single_news(self, article, content, user_info):
+            self.calls += 1
+            return {
+                "title": article["title"],
+                "type": "news",
+                "summary": content,
+                "url": article["url"],
+            }
+
+    class Breaker:
+        async def call(self, fn, *args):
+            return await fn(*args)
+
+    class Breakers:
+        def get(self, name: str) -> Breaker:
+            return Breaker()
+
+    reports: list[list[LinkQualityOutcome]] = []
+    service = EnhancedDigestService.__new__(EnhancedDigestService)
+    service.content_extractor = Extractor()
+    service.llm_client = LLM()
+    service.circuit_breakers = Breakers()
+    service.link_quality_reporter = lambda outcomes: reports.append(list(outcomes))
+    articles = [
+        RankedArticle(
+            title=f"Story {index}",
+            authors=["Reporter"],
+            subject="news",
+            score_reason="Useful preview content",
+            relevance_score=90,
+            abstract_url=f"https://publisher.example/story-{index}",
+            type=ContentType.NEWS,
+        )
+        for index in (1, 2)
+    ]
+
+    summaries = asyncio.run(service._process_news_parallel(articles, {"name": "Ada"}))
+
+    assert len(summaries) == 2
+    assert service.llm_client.calls == 2
+    assert len(reports) == 1
+    assert [outcome.status for outcome in reports[0]] == [
+        LinkAccessStatus.UNKNOWN,
+        LinkAccessStatus.BROKEN,
+    ]


### PR DESCRIPTION
## Why

Two initial feedback responses independently flagged broken/paywalled links. Before adding badges, filtering sources, or changing UI, measure the actual prevalence in production.

## What

### Link-quality observability (no second publisher fetch)
- Reuses the **existing Tavily Extract response** already needed to summarize each selected news URL.
- Conservative statuses: `accessible`, `suspected_paywall`, `broken`, `unknown`.
  - `broken` only from explicit provider failure evidence (404/410/DNS/invalid URL), never article prose.
  - ambiguous 403/timeouts/provider failures stay `unknown`.
- Emits **one bounded Logfire event per digest**: `Digest link quality measured`, with counts + percentages only.
- Logs **no URLs, domains, titles, article content, task/user IDs, emails, or raw provider errors**.
- Preserves preview-based summary fallback if extraction/telemetry breaks.
- Keeps one bounded retry for transport/429/5xx; repeated 429 opens an in-process circuit for the rest of the UTC day (auto-reset next day).
- Redirects deliberately remain unmeasured because Tavily has no reliable redirect chain and we will not probe publishers.

### Temporary feedback CTA
- Adds `Help shape Paperboy` → https://tally.so/r/A7G02o before the footer in shared Jinja digest HTML (email + Dashboard).
- Configurable with `FEEDBACK_CTA_ENABLED` (default true) and `FEEDBACK_FORM_URL`; disable after the feedback window without another template edit.

## Deliberately not included
- No paywall/broken badges.
- No filtering or ranking changes.
- No frequency changes.
- No DB schema/migrations.
- No deployment in this PR.

## Verification
- Full backend suite: **91 passed, 1 skipped**.
- `python -m compileall -q src tests` passed.
- Fresh real Jinja render: CTA URL exactly once, before footer (6,244-byte HTML).
- `git diff --check` passed.
- Three read-only reconnaissance/design sub-agents + two independent review passes; all blockers addressed.

## Companion frontend PR
The stored digest HTML is sandboxed in Dashboard. Companion PR allows the Tally tab to escape iframe restrictions: https://github.com/mogilventures/paperboy-frontend/pull/10
