### PR TITLE
Fix orchestration abort after source checkpoint timeout

### DIFF
--- a/src/news_fetcher.py
+++ b/src/news_fetcher.py
@@ -280,7 +280,6 @@ class NewsAPIFetcher:
             'sortBy': settings.news_sort_by,
             'searchIn': settings.news_search_in,
             'pageSize': min(page_size, 100),
-            'apiKey': self.api_key
         }
         
         # Add optional filters
@@ -298,7 +297,13 @@ class NewsAPIFetcher:
             "api_url": f"{self.base_url}?q={query}&from={from_date}&to={to_date}"
         })
         
-        response = await self.client.get(self.base_url, params=params)
+        # NewsAPI accepts X-Api-Key authentication. Keep credentials out of
+        # the URL so HTTP access logs and provider traces cannot expose them.
+        response = await self.client.get(
+            self.base_url,
+            params=params,
+            headers={"X-Api-Key": self.api_key},
+        )
         
         # Handle rate limiting
         if response.status_code == 429:

--- a/src/orchestration_adapters.py
+++ b/src/orchestration_adapters.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from datetime import date
 from typing import Any
 
 from .models import DigestStatus, TaskStatus
 from .orchestration import GeneratedDigest, Profile
+
+logger = logging.getLogger(__name__)
 
 
 class BackendSourceFetcher:
@@ -42,9 +45,19 @@ class BackendSourceFetcher:
         }
         # The existing-source fast path returns before FetchSourcesService
         # updates its task record, so make completion explicit and idempotent.
-        await self._state_manager.update_fetch_task(
-            task_id, "completed", result=counts
-        )
+        # This tracking checkpoint is nonessential once valid source counts
+        # have been returned; a transient database failure must not discard a
+        # successful fetch and abort every digest in the batch.
+        try:
+            await self._state_manager.update_fetch_task(
+                task_id, "completed", result=counts
+            )
+        except Exception:
+            logger.warning(
+                "Could not checkpoint completed source fetch; continuing with fetched sources",
+                exc_info=True,
+                extra={"task_id": task_id, "source_date": source_date_text},
+            )
         return counts
 
 

--- a/tests/test_news_fetcher.py
+++ b/tests/test_news_fetcher.py
@@ -1,0 +1,53 @@
+"""Behavioral tests for NewsAPI requests."""
+
+import asyncio
+
+import httpx
+
+from src.config import settings
+from src.news_fetcher import NewsAPIFetcher
+
+
+def test_news_api_credentials_are_sent_in_a_header_not_the_url(monkeypatch) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "status": "ok",
+                "totalResults": 1,
+                "articles": [
+                    {
+                        "title": "AI update",
+                        "description": "AI research news",
+                        "url": "https://example.com/ai-update",
+                        "publishedAt": "2026-07-23T12:00:00Z",
+                        "source": {"name": "Example"},
+                    }
+                ],
+            },
+        )
+
+    monkeypatch.setattr(settings, "newsapi_key", "test-news-key")
+    fetcher = NewsAPIFetcher()
+    original_client = fetcher.client
+    fetcher.client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    fetcher._min_request_interval = 0
+
+    async def run_fetch() -> list[dict]:
+        await original_client.aclose()
+        try:
+            return await fetcher.fetch_news(
+                queries=["AI"], target_date="2026-07-23", max_articles=10
+            )
+        finally:
+            await fetcher.close()
+
+    articles = asyncio.run(run_fetch())
+
+    assert len(articles) == 1
+    assert len(requests) == 1
+    assert "apiKey" not in requests[0].url.params
+    assert requests[0].headers["x-api-key"] == "test-news-key"

--- a/tests/test_orchestration_adapters.py
+++ b/tests/test_orchestration_adapters.py
@@ -63,6 +63,22 @@ def test_backend_source_fetcher_completes_tracking_for_cached_sources() -> None:
     )
 
 
+def test_backend_source_fetcher_does_not_discard_sources_when_tracking_fails() -> None:
+    class FailingCompletionStateManager(RecordingFetchStateManager):
+        async def update_fetch_task(self, *args, **kwargs) -> None:
+            raise RuntimeError("tracking gateway timeout")
+
+    fetcher = BackendSourceFetcher(
+        state_manager=FailingCompletionStateManager(),
+        fetch_service=ExistingSourceService(),
+        timeout_seconds=30,
+    )
+
+    counts = asyncio.run(fetcher.fetch(date(2026, 7, 9)))
+
+    assert counts == {"arxiv_count": 8, "news_count": 3}
+
+
 class RecordingDigestService:
     def __init__(self) -> None:
         self.calls = []


### PR DESCRIPTION
## Summary
- treat the post-fetch tracking checkpoint as best-effort after valid sources are available
- send NewsAPI credentials via `X-Api-Key` instead of query parameters so request logs do not expose them
- add regressions for both behaviors

## Production incident
The 2026-07-24 run fetched and stored 487 papers and 47 news articles, then a redundant `fetch_tasks` completion PATCH returned a Supabase 504. The adapter treated that bookkeeping failure as fatal before digest generation began.

## Verification
- `pytest -q` — 93 passed, 1 skipped
- fresh app import — passed
- Docker build — passed
- container `/health` smoke check — passed
- deployed to Fly release v36; live `/health` returns 200
- manual retry completed 48/48 with 0 failures
